### PR TITLE
Column fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,4 +24,4 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Google Analytics references since GTM is used.
 
 ### Fixed
-- Nothing.
+- Two-column lists with an odd number of items no longer spill into a third column

--- a/src/v0/form/css/complain.css
+++ b/src/v0/form/css/complain.css
@@ -1,8 +1,8 @@
 /**
- * 
+ *
  * Complain
  * CFPB "Submit a complaint" forms
- * 
+ *
  */
 
 
@@ -12,11 +12,11 @@
 
 
 body .wrapper-body {
-	
+
 }
 
 body .wrapper-container {
-	margin: 0 auto;	
+	margin: 0 auto;
 	padding-bottom: 18px;
 	overflow: visible;
 }
@@ -35,7 +35,7 @@ body .wrapper-container.annoslide {
 }
 
 body p, body label {
-	
+
 	font-size: 16px;
 }
 
@@ -317,7 +317,7 @@ CHANGE TO GIVE ANNOTATIONS SPACE
 
 .cr-question.cr-sub-question {
     background-color: #f2f2f2;
-    border-top: 0; 
+    border-top: 0;
 }
 
 .cr-question.even {
@@ -370,11 +370,11 @@ CHANGE TO GIVE ANNOTATIONS SPACE
 .cruxform .cr-question-with-checkbox,
 .cruxform .cr-question-with-checkbox .cr-question-left {
 	width: 466px;
-    
+
 }
 
 .cruxform .cr-question.normal-checkbox label.radio.block {
-	
+
 	text-indent: 0;
 	background-color: none;
 }
@@ -386,20 +386,20 @@ CHANGE TO GIVE ANNOTATIONS SPACE
 .cruxform .cr-label select {
 	float: left;
 	clear: left;
-	width: 286px;	
+	width: 286px;
 	margin-left: 18px;
 }
 
 .cruxform .cr-question-left input.zipinput,
 .cruxform .cr-question-right input.zipinput {
 	width: 100px;
-	
+
 }
 
 
 cruxform .cr-question-left input.accountinput {
 	width: 220px;
-	
+
 }
 
 
@@ -410,19 +410,19 @@ cruxform .cr-question-left input.accountinput {
 	clear: none;
 	width: auto;
 	margin: 0px;
-	
-	
+
+
 }
 
 
 .cruxform .cr-question-left input.checkbox {
-	
+
 	margin-left: 2px;
 }
 
 .cruxform .cr-question-with-checkbox input {
-	
-		width: 452px;	
+
+		width: 452px;
 		height: 28px;
 		margin-bottom: 8px;
 	padding-left: 8px;
@@ -431,12 +431,12 @@ cruxform .cr-question-left input.accountinput {
 
 
 .cruxform .zipcode-row .cr-question-right {
-	
+
 	width: 280px;
 }
 
 .cruxform .account-number-row .cr-question-right {
-	
+
 	width: 200px;
 }
 
@@ -447,7 +447,7 @@ cruxform .cr-question-left input.accountinput {
 
 .cruxform .cr-question-right.question-checkbox {
 	margin-left: 18px;
-	width: 300px;	
+	width: 300px;
 
 }
 
@@ -457,7 +457,7 @@ cruxform .cr-question-left input.accountinput {
 	margin-left: 18px;
     padding-left: 0px;
     margin-top: 8px;
-   
+
 }
 
 .cruxform .cr-question-right.question-checkbox label {
@@ -486,7 +486,7 @@ cruxform .cr-question-left input.accountinput {
 
 .cruxform .cr-question .helper-left {
 	margin-top: 8px;
-	
+
 }
 
 .cruxform .cr-question-right p {
@@ -494,13 +494,13 @@ cruxform .cr-question-left input.accountinput {
 }
 
 .cruxform .cr-question-left p {
-	margin: 44px 0px 4px 18px; 
+	margin: 44px 0px 4px 18px;
 }
 
 
 .cruxform .cr-fieldset .cr-question-last {
 	padding-bottom: 24px;
-	
+
 }
 
 .cr-question.cr-typeahead .cr-label {
@@ -716,7 +716,7 @@ input.international,
 }
 
 #terms{
-    margin-right:10px;    
+    margin-right:10px;
 }
 
 
@@ -1042,7 +1042,7 @@ dd.cr-disclose {
 }
 
 /* Icons
-   ========================================================================== 
+   ==========================================================================
 */
 .cr-why {
     font-family: "Avenir Next Demi", Arial, sans-serif;
@@ -1128,7 +1128,7 @@ dd.cr-disclose {
 
 
 #sticky-nav {
-	
+
 }
 
 #sticky-nav.affix {
@@ -1493,9 +1493,9 @@ ADD EXCITING BENCODE
  display: inline-block;
   column-count: 2;
   -moz-column-count: 2;
-  -webkit-column-count: 2;	
+  -webkit-column-count: 2;
  width: 100%;
- -webkit-column-gap: 4px;	
+ -webkit-column-gap: 4px;
  vertical-align: top;
 
 }
@@ -1505,10 +1505,10 @@ ADD EXCITING BENCODE
 	display: inline-block;
   column-count: 2;
   -moz-column-count: 2;
-  -webkit-column-count: 2;	
+  -webkit-column-count: 2;
  width: 100%;
- -webkit-column-gap: 4px;	
- vertical-align: top;	
+ -webkit-column-gap: 4px;
+ vertical-align: top;
 }
 
 
@@ -1519,8 +1519,6 @@ ADD EXCITING BENCODE
 #resolution_options label.block,
 .cr-radios label {
   display: inline-block;
-  float: left;
-  clear: left;
   position: relative;
   background: #dee0e2;
   width: 100%;
@@ -1528,19 +1526,17 @@ ADD EXCITING BENCODE
   padding: 18px 30px 15px 45px;
   margin-bottom: 4px;
   margin-right: 4px;
-  cursor: pointer; 
+  cursor: pointer;
 
   }
-  
-  
+
+
 .prodselect label.block,
 .issueselect label.block,
 #payday_questions_options label.block,
 #resolution_options label.block,
 .select-save-method label.block {
   display: inline-block;
-  float: left;
-  clear: left;
   position: relative;
   background: #dee0e2;
   width: 100%;
@@ -1548,17 +1544,17 @@ ADD EXCITING BENCODE
   padding: 18px 30px 15px 45px;
   margin-bottom: 4px;
   margin-right: 4px;
-  cursor: pointer; 
+  cursor: pointer;
 /*
 -webkit-column-break-inside:avoid;
 -moz-column-break-inside:avoid;
 -o-column-break-inside:avoid;
 -ms-column-break-inside:avoid;
-column-break-inside:avoid;  
+column-break-inside:avoid;
 */
 -webkit-margin-before: 2px;
 -webkit-margin-after: 2px;
-  }  
+  }
 /*
   @media (min-width: 641px) {
     .block-label {
@@ -1587,63 +1583,63 @@ column-break-inside:avoid;
 
 .js-enabled .focused input:focus {
   outline: none; }
-  
-  
-  
+
+
+
 .cruxform h2 {
 	font-size: 26px;
     line-height: 33px;
     margin-top: 0;
     margin-bottom: 8px;
     text-transform: none;
-}  
-  
-  
+}
+
+
 .cruxform h3 {
 	font-size: 22px;
     line-height: 28px;
     margin-top: 0;
     margin-bottom: 8px;
     text-transform: none;
-}  
+}
 
 
 .cruxform p {
 	max-width: 718px;
-	
+
 }
 
 
 .cruxform h3 {
-	
+
 	padding-top: 42px;
 }
 
 
 .whathappened textarea {
-	
+
 	width: 718px;
 }
 
 
 .cruxform .cr-answer-left input {
 	width: 286px;
-	
+
 }
 
 .cruxform .subproduct-list {
 /* 	width: 600px; */
-	
+
 }
-  
+
 
 
 /*
 
 .cruxform #zombie_subissues_sublabel {
 	margin-top: 24px;
-	
-	
+
+
 }
 */
 
@@ -1651,14 +1647,14 @@ column-break-inside:avoid;
 
 /*
 .cruxform #credit_reporting_subissues {
-	
+
 	padding-bottom: 200px;
-	
+
 }
 */
 
 #zombie_subissues_sublabel {
-	
+
 /* 	margin-top: 250px; */
 }
 
@@ -1673,18 +1669,18 @@ column-break-inside:avoid;
 
 	  background: #DBEDD4;
 	  border: 1px solid #2CB34A;
-	  
+
 
 }
 
 .cruxform a {
 	text-decoration: underline
-	
+
 }
 
 p.page-intro,
 p.page-intro2 {
-	
+
 	font-size: 18px;
 	line-height: 24px;
 	padding-bottom: 8px;
@@ -1698,22 +1694,22 @@ p.page-intro-small {
 
 p.page-intro.extra-bottom {
 	margin-bottom: 16px;
-	
+
 }
 
-.cruxform #save-and-continue-later-link, 
+.cruxform #save-and-continue-later-link,
 .cruxform #continue-button,
 .cruxform #save-and-continue-review-page {
 
 	text-align: right;
 	float: right;
 	display: block;
-	
+
 }
 
 .cruxform #save-and-continue-later-link,
 .cruxform #save-and-continue-review-page {
-	
+
 	padding-right: 32px;
 	padding-top: 8px;
 }
@@ -1733,26 +1729,26 @@ p.page-intro.extra-bottom {
 .attachments .cr-question-left p {
 	font-size: 16px;
 	margin-top: 14px;
-	
+
 }
 
 
 .cruxform.yourinfo p {
-	
+
 	margin-bottom: 12px;
 }
 
 
 .cruxform .forward-company-details {
 /* 	margin-top: 14px; */
-	
+
 }
 
 
 /*
 
 cruxform input.company-name-input {
-	
+
 	height: 40px;
 }
 
@@ -1765,31 +1761,31 @@ cruxform input.company-name-input {
 
 
 .company-name-option {
-	
+
 	height: 72px;
 	padding-top: 16px;
 	padding-bottom: 16px;
 	border-top: 1px dotted #aaa;
 	width: 500px;
-	
+
 }
 
 .company-name-option p {
 	width: 280px;
 	padding-right: 20px;
-	
+
 }
 
 .company-name-option label,
 .company-name-option p {
-	
+
 	float:  left;
 	text-align: top;
 }
 
 
 .company-name-option label {
-	
+
 	padding-top: 16px;
 }
 
@@ -1803,14 +1799,14 @@ cruxform input.company-name-input {
 
 .company-not-boarded-info h3,
 .company-not-boarded-info p {
-	
+
 	padding-left: 18px;
 }
 
 
 .company-not-boarded-info .cr-question-with-checkbox input {
 	margin-left: 18px;
-	
+
 }
 
 
@@ -1818,14 +1814,14 @@ cruxform input.company-name-input {
 	margin-left: 18px;
 	width: 452px;
 	overflow: visible;
-	
+
 }
 
 
 
 
 fieldset.narrative-consent {
-	width: 720px;	
+	width: 720px;
 	margin-top: 24px;
 	margin-bottom: 28px;
 }
@@ -1847,32 +1843,32 @@ fieldset.narrative-consent {
 .cr-question-certify-checkbox p {
 	line-height: 1.4em;
 	margin: .2em;
-	
+
 }
 
 
 .cr-consent-checkbox {
-	overflow: visible;	
-	margin-left: 10px;	
+	overflow: visible;
+	margin-left: 10px;
 	margin-top: 6px;
 }
 
 .cr-certify-checkbox {
-	overflow: visible;	
-	margin-left: 4px;	
+	overflow: visible;
+	margin-left: 4px;
 }
 
 
 
 
 .cr-certify-checkbox label {
-	margin-left: 12px;	
+	margin-left: 12px;
 }
 
 /*
 .cr-question-consent-checkbox label {
-    font-family: "Avenir Next", Arial, sans-serif;	
-	
+    font-family: "Avenir Next", Arial, sans-serif;
+
 }
 */
 
@@ -1886,11 +1882,11 @@ fieldset.narrative-consent {
 	font-family: "Avenir Next", Arial, sans-serif;
 	font-weight: 400;
 	font-size: 16px;
-	
+
 }
 
 .cr-question-consent-checkbox input.consent-checkbox {
-	padding: 0px 8px 3px 18px;	
+	padding: 0px 8px 3px 18px;
 	margin-right: 13px !important
 }
 
@@ -1920,13 +1916,13 @@ fieldset.narrative-consent {
 
 .cr-save-option label {
 	margin-left: 0px;
-	padding-left: 0px;	
-	
+	padding-left: 0px;
+
 }
 
 hr.save-method-hr,
 #save-options hr {
-	
+
 	border: 1px dashed #ccc;
 }
 
@@ -1942,19 +1938,19 @@ fieldset.save-method {
 	background: #FFECD1;
 	padding: 12px;
 	margin: 24px 0px 12px 0px;
-	
-	
+
+
 }
 
 #attachment-alert-icon {
 	padding: 8px 0px 8px 8px;
 	margin: 12px;
-	
+
 }
 
 #attachment-alert p {
 	margin-top: 10px;
-	
+
 }
 
 
@@ -1963,7 +1959,7 @@ fieldset.save-method {
 
 button.secondary {
 	background: #75787B;
-	
+
 }
 
 .confirmation-2-column {
@@ -1971,11 +1967,11 @@ button.secondary {
 	padding-right: 54px;
 	float: left;
 	padding-bottom: 72px;
-	
+
 }
 
 .confirmation-2-column p {
-	
+
 	padding-bottom: 8px;
 }
 
@@ -1984,7 +1980,7 @@ button.secondary {
 	float: left;
 	clear: left;
 	padding-bottom: 28px;
-	
+
 }
 
 #complaint-numbers {
@@ -2001,20 +1997,20 @@ button.secondary {
 	margin-top: 48px;
 	margin-bottom: 8px;
 	border: 1px solid #ccc;
-	
+
 }
 
 #scrubbed-narrative {
-  margin: 36px 24px 32px 24px;	
+  margin: 36px 24px 32px 24px;
   font-size: 14px;
   line-height: 21px;
   color: #75787B;
-  
+
 }
 
 #scrubbed-narrative span.redacted-text {
 	background: #75787B;
-	
+
 }
 
 
@@ -2034,8 +2030,8 @@ button.secondary {
 #review-sections .review-section {
 	margin-bottom: 18px;
     padding: 6px 20px 28px 20px;
-	height: auto;	
-	background: #f2f2f2;	
+	height: auto;
+	background: #f2f2f2;
 }
 
 #review-sections .review-column {
@@ -2057,7 +2053,7 @@ button.secondary {
 	display: block;
 	float: left;
 	clear: left;
-	
+
 }
 
 #review-narrative-consent {
@@ -2091,8 +2087,8 @@ button.secondary {
 	display: block;
 	width: 18%;
 	float: left;
-    margin-top: 24px;	
-	
+    margin-top: 24px;
+
 }
 
 
@@ -2112,8 +2108,8 @@ button.secondary {
 #attachment-fieldset {
 	margin-bottom: 42px;
     padding: 6px 20px 16px 20px;
-	height: auto;	
-	background: #f2f2f2;		
+	height: auto;
+	background: #f2f2f2;
 }
 
 #attachment-drag-drop-area {
@@ -2127,13 +2123,13 @@ button.secondary {
 	text-align: center;
 	width: 100%;
 	padding-bottom: 24px;
-	
+
 }
 
 #attachment-drag-instructions {
 	font-size: 20px;
     color: #75787B;
-	
+
 }
 
 
@@ -2149,11 +2145,11 @@ button.secondary {
 .cr-modal .your-id-number {
 	font-size: 20px;
 	padding: 8px 0;
-	
+
 }
 
 .product-specific-questions .follow-up {
-	
+
 }
 
 .product-specific-questions .follow-up label {
@@ -2169,11 +2165,11 @@ button.secondary {
 
 
 .product-specific-questions .cr-question-with-sidebar {
-	width: 392px;	
+	width: 392px;
 }
 
 .product-specific-questions .cr-question-with-sidebar input {
-	width: 368px;	
+	width: 368px;
 }
 
 
@@ -2191,12 +2187,12 @@ button.secondary {
 
 .product-specific-questions .cr-question-left label {
 	padding-bottom: 8px;
-	
+
 }
 
 .welcome h2 {
 	margin-top: 18px;
-	
+
 }
 
 ul#welcome-list {
@@ -2209,12 +2205,12 @@ ul#welcome-list li {
 	font-size: 20px;
 	line-height: 26px;
 	padding-bottom: 16px;
-	
+
 }
 
 
 #get-started-button {
-	padding-right: 22px;	
+	padding-right: 22px;
 }
 
 #get-started-button button {
@@ -2224,7 +2220,7 @@ ul#welcome-list li {
 
 #get-started-button button:hover {
 	background-color: #328ed8;
-	
+
 }
 
 
@@ -2236,7 +2232,7 @@ ul#welcome-list li {
 #consumer2-identity .right-helper,
 .point-of-contact #poc-access-div {
 	padding-top: 20px;
-	
+
 }
 
 #consumer2-identity .right-helper label,
@@ -2256,7 +2252,8 @@ h3 .helper-instructions {
 }
 
 #resolution_options {
-	width: 100%;	
+    box-sizing: border-box;
+	width: 100%;
 	float: left;
 	padding-top: 0;
 }
@@ -2266,16 +2263,16 @@ h3 .helper-instructions {
 }
 
 #resolution-options-list {
-	
+
 	width: 100%;
 	clear: left;
-		
+
 }
 
 #annotations-sidebar {
 	width: 400px;
 	padding-right: 20px;
-	margin-right: 16px;	
+	margin-right: 16px;
 	margin-top: 0px;
 	position: fixed;
 	top: 0;
@@ -2287,11 +2284,11 @@ overflow-x: scroll;
 	background: #F8F8F8;
 	border-right: 6px solid #E3E4E5;
 	height: 100%;
-	
+
 }
 
 #annotations-toggle {
-	font-size: 16px;	
+	font-size: 16px;
 	padding: 0 0 0 12px;
 
 }
@@ -2358,5 +2355,5 @@ a.annotation-button:hover,
 	padding-top: 8px;
 	padding-left: 24px;
 	font-family: "Avenir Next Medium", Arial, sans-serif
-	
+
 }

--- a/src/your-information.html
+++ b/src/your-information.html
@@ -5,24 +5,24 @@
 <!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
 <head>
 
-<meta charset="utf-8">
+    <meta charset="utf-8">
 
-<title>Submit a complaint | Your information</title>
+    <title>Submit a complaint | Your information</title>
 
-<meta name="description" content="">
-<meta name="viewport" content="width=device-width">
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width">
 
-<link rel="stylesheet" href="v0/form/css/normalize.css">
-<link rel="stylesheet" href="v0/form/css/grid.css">
-<link rel="stylesheet" href="v0/form/css/fonts.css">
-<link rel="stylesheet" href="v0/form/css/new-core.css">
-<link rel="stylesheet" href="v0/form/css/complain.css">
-<link rel="stylesheet" href="v0/form/css/typeahead.css">
-<!-- <link rel="stylesheet" href="v0/form/css/responsive.css"> -->
+    <link rel="stylesheet" href="v0/form/css/normalize.css">
+    <link rel="stylesheet" href="v0/form/css/grid.css">
+    <link rel="stylesheet" href="v0/form/css/fonts.css">
+    <link rel="stylesheet" href="v0/form/css/new-core.css">
+    <link rel="stylesheet" href="v0/form/css/complain.css">
+    <link rel="stylesheet" href="v0/form/css/typeahead.css">
+    <!-- <link rel="stylesheet" href="v0/form/css/responsive.css"> -->
 
-<!-- Custom modernizr for touch detection only, see the .js file for the build link -->
-<script src="v0/form/js/vendor/modernizr.custom.js"></script>
-<script src="v0/form/js/vendor/bootstrap-modal.js"></script>
+    <!-- Custom modernizr for touch detection only, see the .js file for the build link -->
+    <script src="v0/form/js/vendor/modernizr.custom.js"></script>
+    <script src="v0/form/js/vendor/bootstrap-modal.js"></script>
 
 <!--
     Old IE polyfills for:
@@ -37,180 +37,161 @@
 </head>
 <body class="yourinfo cruxform">
 
-<div class="wrapper-banner" style="font-size: 16px;">
-    <div class="wrapper-container">
-        <small class="split">
-            <span class="official-website">An official website of the United States Government</span>
-        </small>
-    </div>
-</div><!-- .wrapper-banner -->
+    <div class="wrapper-banner" style="font-size: 16px;">
+        <div class="wrapper-container">
+            <small class="split">
+                <span class="official-website">An official website of the United States Government</span>
+            </small>
+        </div>
+    </div><!-- .wrapper-banner -->
 
-<header class="wrapper-header">
+    <header class="wrapper-header">
 
-    <div class="wrapper-container">
+        <div class="wrapper-container">
 
-        <div class="brand">
+            <div class="brand">
 
-            <h1> Submit a complaint</h1>
+                <h1> Submit a complaint</h1>
 
-            <a class="brand-logo" href="https://consumerfinance.gov"><img src="v0/form/img/logo-cfpb-retina.png" alt="Consumer Financial Protection Bureau"></a>
+                <a class="brand-logo" href="https://consumerfinance.gov"><img src="v0/form/img/logo-cfpb-retina.png" alt="Consumer Financial Protection Bureau"></a>
 
-        </div><!-- .brand -->
+            </div><!-- .brand -->
 
-    </div><!-- .wrapper-container -->
+        </div><!-- .wrapper-container -->
 
-</header><!-- .wrapper-header -->
+    </header><!-- .wrapper-header -->
 
-<noscript>
-    For full functionality of this application, it is necessary to enable JavaScript.
-    Here are the <a href="http://www.enable-javascript.com/" target="_blank">
-    instructions how to enable JavaScript in your web browser</a>.
-</noscript>
+    <noscript>
+        For full functionality of this application, it is necessary to enable JavaScript.
+        Here are the <a href="http://www.enable-javascript.com/" target="_blank">
+        instructions how to enable JavaScript in your web browser</a>.
+    </noscript>
+    <div class="wrapper-body page-step-1">
 
+        <!-- ANNOTATIONS SIDEBAR -->
 
-<div class="wrapper-body page-step-1">
+        <div id="annotations-sidebar">
+            <p id="annotations-opener"><a href="#">Open annotations</a></p>
 
+            <p id="annotations-toggle" class="opened"><a href="#">Toggle annotations</a></p>
 
-<!-- ANNOTATIONS SIDEBAR -->
+            <ul id="annotations-list">
+                <li class="annotation-format">
+                    <h3 class="anno-title">Title of annotation</h3>
+                    <!--                    <h6 class="anno-date">Date added</h6> -->
+                    <p class="anno-link-text">
+                        <a class="anno-link" href="#">Link to element</a>
+                    </p>
+                    <div class="anno-comment">Placeholder text</div>
+                </li>
+            </ul>
+        </div>
 
-                <div id="annotations-sidebar">
-                <p id="annotations-opener"><a href="#">Open annotations</a></p>
+        <!-- END OF ANNOTATIONS SIDEBAR -->
 
-                <p id="annotations-toggle" class="opened"><a href="#">Toggle annotations</a></p>
-
-                    <ul id="annotations-list">
-                        <li class="annotation-format">
-                            <h3 class="anno-title">Title of annotation</h3>
-<!--                            <h6 class="anno-date">Date added</h6> -->
-                            <p class="anno-link-text"><a class="anno-link" href="#">Link to element</a></p>
-                            <div class="anno-comment">Placeholder text</div>
-                        </li>
-                    </ul>
-
-                </div>
-
-<!-- END OF ANNOTATIONS SIDEBAR -->
-
-
-    <div class="wrapper-container">
+        <div class="wrapper-container">
 
 <!-- =============
      BEGIN CONTENT
      ============= -->
 
-       <section class="content row cr-content">
+     <section class="content row cr-content">
 
-            <!-- nav on the left side of the page -->
-            <nav class="span4 cr-steps secondary">
-                <!-- uses bootstrap's affix plugin -->
-                <div id="sticky-nav">
-                    <ul>
+        <!-- nav on the left side of the page -->
+        <nav class="span4 cr-steps secondary">
+            <!-- uses bootstrap's affix plugin -->
+            <div id="sticky-nav">
+                <ul>
+                    <li class="incomplete"><a href="select-product.html">1</span></a></li>
+                    <li class="incomplete"><a href="select-issue.html">2</a></li>
+                    <li class="incomplete"><a href="what-happened.html">3</a></li>
+                    <li class="incomplete"><a href="company-information.html">4</span></a></li>
+                    <li class="active incomplete"><a href="your-information.html">5</a></li>
+                    <li class="incomplete"><a href="review-and-submit.html">6</a></li>
+                </ul>
+                <!--            <a href="#" id="chat-now">Form trouble? Chat now.</a> -->
+            </div>
+            <!-- /#sticky-nav -->
+        </nav>
+        <!-- /nav on the left side of the page -->
 
+        <div class="span8 cr-primary">
+            <!-- .error-panel -->
 
-                            <li class="incomplete"><a href="select-product.html">1</span></a></li>
+            <!-- end .error-panel -->
 
-                            <li class="incomplete"><a href="select-issue.html">2</a></li>
+            <div style="text-align: right; margin-top: 30px; margin-right: 30px;">
+                Have a question or need for help? <a>Chat Now</a>
+            </div>
 
-                            <li class="incomplete"><a href="what-happened.html">3</a></li>
-
-                            <li class="incomplete"><a href="company-information.html">4</span></a></li>
-
-                            <li class="active incomplete"><a href="your-information.html">5</a></li>
-
-                            <li class="incomplete"><a href="review-and-submit.html">6</a></li>
-
-                    </ul>
-
-<!--                     <a href="#" id="chat-now">Form trouble? Chat now.</a> -->
-
-                </div>
-                <!-- /#sticky-nav -->
-
-            </nav>
-            <!-- /nav on the left side of the page -->
-
-<div class="span8 cr-primary">
-                <!-- .error-panel -->
-
-                <!-- end .error-panel -->
-
-                <div style="text-align: right; margin-top: 30px; margin-right: 30px;">
-                  Have a question or need for help? <a>Chat Now</a>
-                </div>
-
-  <div id="select_product" class="cr-primary-container">
-    <h2>What people are involved?</h2>
-    <p class="page-intro your-info">If you are submitting this complaint for someone else, you can choose to include your contact information in the “point of contact” section.</p>
+            <div id="select_product" class="cr-primary-container">
+                <h2>What people are involved?</h2>
+                <p class="page-intro your-info">If you are submitting this complaint for someone else, you can choose to include your contact information in the “point of contact” section.</p>
 
                 <!-- end .error-panel -->
-        <h3 id="primary-consumer-section">Primary consumer</h3>
-        <p>Tell us about the person who is having this issue.</p>
-<!--        <p>The person who is having this issue</p> -->
-     <fieldset id="consumer1-identity" class="cr-fieldset">
-        <!-- question -->
-         <div class="row cr-question">
+                <h3 id="primary-consumer-section">Primary consumer</h3>
+                <p>Tell us about the person who is having this issue.</p>
+                <!--            <p>The person who is having this issue</p> -->
 
+                <fieldset id="consumer1-identity" class="cr-fieldset">
+                    <!-- question -->
+                    <div class="row cr-question">
+                        <div class="span3 cr-label cr-question cr-question-left cr-question-last">
+                            <label for="primary-consumer-identity">
+                                This person is...
+                                <div class='is-required'>Answer Required</div>
+                            </label>
 
+                            <select name="primary-consumer-identity" id="primary-consumer-identity" class="input-medium">
+                                <option>Select an option...</option>
+                                <option id="primary-consumer-identity-option1" class="consumer-identity-options" value="#">Primary account holder</option>
+                                <option id="primary-consumer-identity-option2" class="consumer-identity-options" value="#">Additional account holder</option>
+                                <option id="primary-consumer-identity-option3" class="consumer-identity-options" value="#">Joint account holder</option>
+                                <option id="primary-consumer-identity-option4" class="consumer-identity-options" value="#">Additional card holder</option>
+            <!--
+                                <option id="primary-consumer-identity-option5" class="consumer-identity-options" value="#">Co-Signer</option>
+                                <option id="primary-consumer-identity-option6" class="consumer-identity-options" value="#">Co-borrower</option>
+                                <option id="primary-consumer-identity-option7" class="consumer-identity-options" value="#">Sender</option>
+                                <option id="primary-consumer-identity-option8" class="consumer-identity-options" value="#">Recipient</option>
+                            -->
+                        </select>
 
-                 <div class="span3 cr-label cr-question cr-question-left cr-question-last">
-                <label for="primary-consumer-identity">
-                    This person is...
-                    <div class='is-required'>Answer Required</div>
-                </label>
+                        <div id="ans-rel-other-who" style="display:none;">
+                            <input type="text" class="input-medium" name="cr-con1-other-who" id="cr-con1-other-who" placeholder="">
+                        </div>
 
-                    <select name="primary-consumer-identity" id="primary-consumer-identity" class="input-medium">
-                        <option>Select an option...</option>
-                        <option id="primary-consumer-identity-option1" class="consumer-identity-options" value="#">Primary account holder</option>
-                        <option id="primary-consumer-identity-option2" class="consumer-identity-options" value="#">Additional account holder</option>
-                        <option id="primary-consumer-identity-option3" class="consumer-identity-options" value="#">Joint account holder</option>
-                        <option id="primary-consumer-identity-option4" class="consumer-identity-options" value="#">Additional card holder</option>
-<!--
-                        <option id="primary-consumer-identity-option5" class="consumer-identity-options" value="#">Co-Signer</option>
-                        <option id="primary-consumer-identity-option6" class="consumer-identity-options" value="#">Co-borrower</option>
-                        <option id="primary-consumer-identity-option7" class="consumer-identity-options" value="#">Sender</option>
-                        <option id="primary-consumer-identity-option8" class="consumer-identity-options" value="#">Recipient</option>
--->
-                    </select>
-
-                    <div id="ans-rel-other-who" style="display:none;">
-                        <input type="text" class="input-medium" name="cr-con1-other-who" id="cr-con1-other-who" placeholder="">
                     </div>
 
+                    <div class="span2 cr-label cr-question-right right-helper">
+                    </div>
                 </div>
+            </fieldset>
 
-                <div class="span2 cr-label cr-question-right right-helper">
+            <fieldset class="cr-fieldset full-name-format">
+
+                <!-- First name and middle name -->
+                <div class="row cr-question ">
+                    <div class="span3 cr-label cr-question-left ">
+                        <label for="cr-first-name2_4851476384792477">
+                            First name
+                        </label>
+                        <input type="text" name="cr-first-name2" id="cr-first-name2_4851476384792477" placeholder="">
+                    </div>
+
+                    <!-- middle name -->
+                    <div class="span2 cr-label cr-question-right">
+                        <label for="cr-middle-name2_4851476384792477">
+                            Middle <small class="inline">(Optional)</small>
+                        </label>
+                        <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477" placeholder="">
+                    </div>
+                    <!-- /middle name -->
                 </div>
+                <!-- /First name and middle name -->
 
-          </div>
-    </fieldset>
-
-    <fieldset class="cr-fieldset full-name-format">
-
-   <!-- First name and middle name -->
-            <div class="row cr-question ">
-                <div class="span3 cr-label cr-question-left ">
-                    <label for="cr-first-name2_4851476384792477">
-                        First name
-                    </label>
-                    <input type="text" name="cr-first-name2" id="cr-first-name2_4851476384792477" placeholder="">
-                </div>
-
-                <!-- middle name -->
-                <div class="span2 cr-label cr-question-right">
-                    <label for="cr-middle-name2_4851476384792477">
-                        Middle <small class="inline">(Optional)</small>
-                    </label>
-                    <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477" placeholder="">
-                </div>
-    <!-- /middle name -->
-            </div>
-<!-- /First name and middle name -->
-
-<!-- Last name and suffix -->
-
-
+                <!-- Last name and suffix -->
                 <div class="row cr-question cr-question-last">
-                <div class="span3 cr-label cr-question-left">
+                    <div class="span3 cr-label cr-question-left">
                         <label for="cr-last-name2_4851476384792477">
                             Last name
                             <div class='is-required'>Answer Required</div>
@@ -225,8 +206,6 @@
                             Suffix
                             <small class="inline">(Optional)</small>
                         </label>
-
-
                         <select name="cr-suffix" id="cr-suffix2_4851476384792477" class="block">
                             <option value="" disabled="disabled" selected="selected">Select...</option>
                             <option value="">Jr</option>
@@ -247,105 +226,99 @@
 
                     </div>
                     <!-- /suffix -->
-
-
                 </div>
                 <!-- /city and state -->
-    </fieldset>
-     <fieldset id="primary-consumer-phone-and-zip" class="cr-fieldset">
+            </fieldset>
+            <fieldset id="primary-consumer-phone-and-zip" class="cr-fieldset">
 
                 <!-- Zip code -->
                 <div class="row cr-question cr-question-last">
-
 
                     <!-- suffix -->
                     <div class="span2 cr-label cr-question-left">
                         <label for="cr-suffix2">
                             Phone number
                         </label>
-                    <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477" placeholder="">
+                        <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477" placeholder="">
 
-                        <!--
-<select name="cr-suffix" id="cr-suffix2_4851476384792477" class="block">
-                            <option value="" disabled="disabled" selected="selected">Select...</option>
-<option label="Alabama" value="2" >Alabama</option>
-                    <option label="Alaska" value="1" >Alaska</option>
-                    <option label="American Samoa" value="4" >American Samoa</option>
-                    <option label="Arizona" value="5" >Arizona</option>
-                    <option label="Arkansas" value="3" >Arkansas</option>
-                    <option label="California" value="6" >California</option>
-                    <option label="Colorado" value="7" >Colorado</option>
-                    <option label="Connecticut" value="8" >Connecticut</option>
-                    <option label="Delaware" value="10" >Delaware</option>
-                    <option label="District Of Columbia" value="9" >District Of Columbia</option>
-                    <option label="Federated States Of Micronesia" value="12" >Federated States Of Micronesia</option>
-                    <option label="Florida" value="11" >Florida</option>
-                    <option label="Georgia" value="13" >Georgia</option>
-                    <option label="Guam" value="14" >Guam</option>
-                    <option label="Hawaii" value="15" >Hawaii</option>
-                    <option label="Idaho" value="17" >Idaho</option>
-                    <option label="Illinois" value="18" >Illinois</option>
-                    <option label="Indiana" value="19" >Indiana</option>
-                    <option label="Iowa" value="16" >Iowa</option>
-                    <option label="Kansas" value="20" >Kansas</option>
-                    <option label="Kentucky" value="21" >Kentucky</option>
-                    <option label="Louisiana" value="22" >Louisiana</option>
-                    <option label="Maine" value="25" >Maine</option>
-                    <option label="Marshall Islands" value="26" >Marshall Islands</option>
-                    <option label="Maryland" value="24" >Maryland</option>
-                    <option label="Massachusetts" value="23" >Massachusetts</option>
-                    <option label="Michigan" value="27" >Michigan</option>
-                    <option label="Minnesota" value="28" >Minnesota</option>
-                    <option label="Mississippi" value="31" >Mississippi</option>
-                    <option label="Missouri" value="29" >Missouri</option>
-                    <option label="Montana" value="32" >Montana</option>
-                    <option label="Nebraska" value="35" >Nebraska</option>
-                    <option label="Nevada" value="39" >Nevada</option>
-                    <option label="New Hampshire" value="36" >New Hampshire</option>
-                    <option label="New Jersey" value="37" >New Jersey</option>
-                    <option label="New Mexico" value="38" >New Mexico</option>
-                    <option label="New York" value="40" >New York</option>
-                    <option label="North Carolina" value="33" >North Carolina</option>
-                    <option label="North Dakota" value="34" >North Dakota</option>
-                    <option label="Northern Mariana Islands" value="30" >Northern Mariana Islands</option>
-                    <option label="Ohio" value="41" >Ohio</option>
-                    <option label="Oklahoma" value="42" >Oklahoma</option>
-                    <option label="Oregon" value="43" >Oregon</option>
-                    <option label="Palau" value="46" >Palau</option>
-                    <option label="Pennsylvania" value="44" >Pennsylvania</option>
-                    <option label="Puerto Rico" value="45" >Puerto Rico</option>
-                    <option label="Rhode Island" value="47" >Rhode Island</option>
-                    <option label="South Carolina" value="48" >South Carolina</option>
-                    <option label="South Dakota" value="49" >South Dakota</option>
-                    <option label="Tennessee" value="50" >Tennessee</option>
-                    <option label="Texas" value="51" >Texas</option>
-                    <option label="Utah" value="52" >Utah</option>
-                    <option label="Vermont" value="55" >Vermont</option>
-                    <option label="Virgin Islands" value="54" >Virgin Islands</option>
-                    <option label="Virginia" value="53" >Virginia</option>
-                    <option label="Washington" value="56" >Washington</option>
-                    <option label="West Virginia" value="58" >West Virginia</option>
-                    <option label="Wisconsin" value="57" >Wisconsin</option>
-                    <option label="Wyoming" value="59" >Wyoming</option>
-                    <option label="Armed Forces Middle East" value="95" >Armed Forces Middle East</option>
-                    <option label="Armed Forces Americas" value="94" >Armed Forces Americas</option>
-                    <option label="Armed Forces Pacific" value="96" >Armed Forces Pacific</option>
-                        </select>
--->
-
+                            <!--
+                            <select name="cr-suffix" id="cr-suffix2_4851476384792477" class="block">
+                                            <option value="" disabled="disabled" selected="selected">Select...</option>
+                                <option label="Alabama" value="2" >Alabama</option>
+                                <option label="Alaska" value="1" >Alaska</option>
+                                <option label="American Samoa" value="4" >American Samoa</option>
+                                <option label="Arizona" value="5" >Arizona</option>
+                                <option label="Arkansas" value="3" >Arkansas</option>
+                                <option label="California" value="6" >California</option>
+                                <option label="Colorado" value="7" >Colorado</option>
+                                <option label="Connecticut" value="8" >Connecticut</option>
+                                <option label="Delaware" value="10" >Delaware</option>
+                                <option label="District Of Columbia" value="9" >District Of Columbia</option>
+                                <option label="Federated States Of Micronesia" value="12" >Federated States Of Micronesia</option>
+                                <option label="Florida" value="11" >Florida</option>
+                                <option label="Georgia" value="13" >Georgia</option>
+                                <option label="Guam" value="14" >Guam</option>
+                                <option label="Hawaii" value="15" >Hawaii</option>
+                                <option label="Idaho" value="17" >Idaho</option>
+                                <option label="Illinois" value="18" >Illinois</option>
+                                <option label="Indiana" value="19" >Indiana</option>
+                                <option label="Iowa" value="16" >Iowa</option>
+                                <option label="Kansas" value="20" >Kansas</option>
+                                <option label="Kentucky" value="21" >Kentucky</option>
+                                <option label="Louisiana" value="22" >Louisiana</option>
+                                <option label="Maine" value="25" >Maine</option>
+                                <option label="Marshall Islands" value="26" >Marshall Islands</option>
+                                <option label="Maryland" value="24" >Maryland</option>
+                                <option label="Massachusetts" value="23" >Massachusetts</option>
+                                <option label="Michigan" value="27" >Michigan</option>
+                                <option label="Minnesota" value="28" >Minnesota</option>
+                                <option label="Mississippi" value="31" >Mississippi</option>
+                                <option label="Missouri" value="29" >Missouri</option>
+                                <option label="Montana" value="32" >Montana</option>
+                                <option label="Nebraska" value="35" >Nebraska</option>
+                                <option label="Nevada" value="39" >Nevada</option>
+                                <option label="New Hampshire" value="36" >New Hampshire</option>
+                                <option label="New Jersey" value="37" >New Jersey</option>
+                                <option label="New Mexico" value="38" >New Mexico</option>
+                                <option label="New York" value="40" >New York</option>
+                                <option label="North Carolina" value="33" >North Carolina</option>
+                                <option label="North Dakota" value="34" >North Dakota</option>
+                                <option label="Northern Mariana Islands" value="30" >Northern Mariana Islands</option>
+                                <option label="Ohio" value="41" >Ohio</option>
+                                <option label="Oklahoma" value="42" >Oklahoma</option>
+                                <option label="Oregon" value="43" >Oregon</option>
+                                <option label="Palau" value="46" >Palau</option>
+                                <option label="Pennsylvania" value="44" >Pennsylvania</option>
+                                <option label="Puerto Rico" value="45" >Puerto Rico</option>
+                                <option label="Rhode Island" value="47" >Rhode Island</option>
+                                <option label="South Carolina" value="48" >South Carolina</option>
+                                <option label="South Dakota" value="49" >South Dakota</option>
+                                <option label="Tennessee" value="50" >Tennessee</option>
+                                <option label="Texas" value="51" >Texas</option>
+                                <option label="Utah" value="52" >Utah</option>
+                                <option label="Vermont" value="55" >Vermont</option>
+                                <option label="Virgin Islands" value="54" >Virgin Islands</option>
+                                <option label="Virginia" value="53" >Virginia</option>
+                                <option label="Washington" value="56" >Washington</option>
+                                <option label="West Virginia" value="58" >West Virginia</option>
+                                <option label="Wisconsin" value="57" >Wisconsin</option>
+                                <option label="Wyoming" value="59" >Wyoming</option>
+                                <option label="Armed Forces Middle East" value="95" >Armed Forces Middle East</option>
+                                <option label="Armed Forces Americas" value="94" >Armed Forces Americas</option>
+                                <option label="Armed Forces Pacific" value="96" >Armed Forces Pacific</option>
+                            </select>
+                        -->
                     </div>
                     <!-- /suffix -->
                     <div class="span3 cr-label cr-question-right">
-                    <label for="cr-first-name2_4851476384792477">
-                        Zip Code
-                    </label>
-                    <input type="text" name="con1-zip" id="con1-zip" class="zipinput" placeholder="">
+                        <label for="cr-first-name2_4851476384792477">
+                            Zip Code
+                        </label>
+                        <input type="text" name="con1-zip" id="con1-zip" class="zipinput" placeholder="">
                     </div>
+                </div>
 
-          </div>
-
-
-            <div class="row cr-question ">
+                <div class="row cr-question ">
                     <div class="span3 cr-label cr-question-left ">
                         <label for="cr-first-name2_4851476384792477">
                             Address line 1
@@ -360,75 +333,51 @@
                         <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477" placeholder="">
                     </div>
                 </div>
-
-
-                    <div class="row cr-question cr-question-last">
+                <div class="row cr-question cr-question-last">
                     <div class="span3 cr-label cr-question-left">
-                            <label for="cr-last-name2_4851476384792477">
-                                Address line 2 <small class="inline">(Optional)</small>
-                                <div class='is-required'>Answer Required</div>
-                            </label>
+                        <label for="cr-last-name2_4851476384792477">
+                            Address line 2 <small class="inline">(Optional)</small>
+                            <div class='is-required'>Answer Required</div>
+                        </label>
 
-                            <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
-                        </div>
-
-                        <!-- suffix -->
-                        <div class="span2 cr-label cr-question-right">
-                            <label for="cr-suffix2">
-                                State
-                                <small class="inline"></small>
-                            </label>
-
-
-                            <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
-
-
-                        </div>
-                        <!-- /suffix -->
-
-
+                        <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
                     </div>
 
+                    <!-- suffix -->
+                    <div class="span2 cr-label cr-question-right">
+                        <label for="cr-suffix2">
+                            State
+                            <small class="inline"></small>
+                        </label>
+
+                        <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
+                    </div>
+                    <!-- /suffix -->
                 </div>
-
-
-                <!-- /zip code  -->
-    </fieldset>
+            </fieldset>
 
 <!--
+                <fieldset class="cr-fieldset">
+                    <div class="row cr-question cr-question-last">
+                        <div class="span2 cr-label cr-question-left">
+                            <label for="cr-first-name2_4851476384792477">
+                                Zip Code
+                            </label>
+                            <input type="text" name="con1-zip" id="con1-zip" class="zipinput" placeholder="">
 
-<fieldset class="cr-fieldset">
-
-                <div class="row cr-question cr-question-last">
-
-
-                    <div class="span2 cr-label cr-question-left">
-                                            <label for="cr-first-name2_4851476384792477">
-                        Zip Code
-                    </label>
-                    <input type="text" name="con1-zip" id="con1-zip" class="zipinput" placeholder="">
-
-
+                        </div>
+                        <div class="span3 cr-label cr-question-right">
+                        <p>This is important because lending laws often have provisions for people in different age groups.</p>
+                        </div>
                     </div>
-                    <div class="span3 cr-label cr-question-right">
-                    <p>This is important because lending laws often have provisions for people in different age groups.</p>
-                    </div>
-
-                </div>
+                </fieldset>
+            -->
 
 
-    </fieldset>
-
--->
-
-
-
-
-     <fieldset id="primary-consumer-email" class="cr-fieldset">
-
+            <fieldset id="primary-consumer-email" class="cr-fieldset">
 
                 <!-- email address -->
-            <div class="cr-question borrower-email cr-question-last">
+                <div class="cr-question borrower-email cr-question-last">
                     <div class="span3 cr-label cr-question-left cr-question-with-checkbox">
                         <label for="con1-email">
                             Email address <!-- <small class="inline">(This is required for official correspondence)</small> -->
@@ -439,16 +388,13 @@
                         <p>We’ll use this email address to send updates about the status of this complaint. It will also be the username for the account.</p>
                     </div>
                     <div class="span2 cr-label cr-question-right right-helper question-checkbox">
-                                <label id="no-email-address-checkbox" class="radio block">
-                                    <input type="checkbox" name="no-email" value="no-email" class="cr-no-email checkbox" id="cr-no-email">
-                                    The primary consumer doesn't have an email address
-                                </label>
+                        <label id="no-email-address-checkbox" class="radio block">
+                            <input type="checkbox" name="no-email" value="no-email" class="cr-no-email checkbox" id="cr-no-email">
+                            The primary consumer doesn't have an email address
+                        </label>
                     </div>
-            </div>
+                </div>
                 <!-- /email  -->
-
-
-
 
 <!--
 
@@ -456,40 +402,33 @@
 
 -->
 
+<div id="consumer-info-no-email" class="row cr-question">
 
-            <div id="consumer-info-no-email" class="row cr-question">
+    <div class="span3 cr-label" style="border-top: dotted 1px #ccc; padding-top: 12px;">
+        <label>
+         How should we contact the primary consumer about the status of this complaint?
+         <div class='is-required'>Required</div>
+     </label>
+ </div>
 
-                    <div class="span3 cr-label" style="border-top: dotted 1px #ccc; padding-top: 12px;">
-                        <label>
-                           How should we contact the primary consumer about the status of this complaint?
-                            <div class='is-required'>Required</div>
-                        </label>
+ <div class="span9 cr-answer cr-radios prodselect cr-behalf">
+    <label class="radio block">
+        <input type="radio" class='identify-account identify-user identification-type phone-number' name="identify-account" value="phone-number">
+        Text message
+    </label>
 
-                    </div>
+    <label class="radio block">
+        <input type="radio" class='identify-account identify-user identification-type physical-mail' name="identify-account" value="physical-mail">
+        Mail
+    </label>
 
-                    <div class="span9 cr-answer cr-radios prodselect cr-behalf">
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identify-user identification-type phone-number' name="identify-account" value="phone-number">
-                            Text message
-                        </label>
-
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identify-user identification-type physical-mail' name="identify-account" value="physical-mail">
-                            Mail
-                        </label>
-
-                        <label class="radio block last">
-                            <input type="radio" class='identify-account identify-user identification-type someone-else' name="identify-account" value="someone-else">
-                            Someone else will be the point of contact
-                        </label>
-
-
-                    </div>
-            </div>
-
-    </fieldset>
-
-
+    <label class="radio block last">
+        <input type="radio" class='identify-account identify-user identification-type someone-else' name="identify-account" value="someone-else">
+        Someone else will be the point of contact
+    </label>
+</div>
+</div>
+</fieldset>
 <fieldset class="cr-fieldset identify-options physical-mail">
 
   <div class="row cr-question cr-question-last account-number-row">
@@ -498,49 +437,30 @@
           <p style="margin: 1em;">We will mail updates each time your complaint changes status.</p>
       </div>
   </div>
+</fieldset>   <!--  /physical mail   -->
 
-    </fieldset>   <!--  /physical mail   -->
+<fieldset class="cr-fieldset identify-options phone-number">
+    <div class="row cr-question cr-question-last account-number-row">
+        <div class="span3 cr-label">
+            <p style="margin: 1em;">We will text a message to the number you provided each time your complaint changes in status. Standard messaging rates may apply.</p>
+        </div>
+    </div>
+</fieldset>
 
+<fieldset class="cr-fieldset identify-options someone-else">
 
+    <div class="row cr-question cr-question-last account-number-row">
+        <div class="span3 cr-label">
+         <p style="margin: 1em;">Be sure to include full contact information below.</p>
+     </div>
 
-
-
-     <fieldset class="cr-fieldset identify-options phone-number">
-
-            <div class="row cr-question cr-question-last account-number-row">
-
-                <div class="span3 cr-label">
-                    <p style="margin: 1em;">We will text a message to the number you provided each time your complaint changes in status. Standard messaging rates may apply.</p>
+        <!--
+                        <div class="span2 cr-label cr-question-right right-helper">
+                            <p></p>
+                        </div>
+                    -->
                 </div>
-            </div>
-
-
-    </fieldset>
-
-
-
-
-
-     <fieldset class="cr-fieldset identify-options someone-else">
-
-            <div class="row cr-question cr-question-last account-number-row">
-                <div class="span3 cr-label">
-                   <p style="margin: 1em;">Be sure to include full contact information below.</p>
-                </div>
-
-<!--
-                <div class="span2 cr-label cr-question-right right-helper">
-                    <p></p>
-                </div>
--->
-            </div>
-
-
-    </fieldset>
-
-
-
-
+            </fieldset>
 
 <!--
 
@@ -548,10 +468,7 @@ END CONSUMER NO EMAIL ADDRESS
 
 -->
 
-
-
 </div>
-
 
 <!--
 //////////
@@ -561,53 +478,45 @@ ADDITIONAL CONSUMER. SAME AS ABOVE CONTENT, MOSTLY
 -->
 
 <div class="cr-primary-container">
-        <h3 id="additional-consumer-section">Additional consumer</h3>
-<!--        <p>Someone who shares the account or participated in the transaction</p> -->
+    <h3 id="additional-consumer-section">Additional consumer</h3>
+    <!--        <p>Someone who shares the account or participated in the transaction</p> -->
 
     <fieldset class="cr-fieldset">
         <!-- question -->
-<div class="row cr-question">
-    <fieldset class="cr-fieldset">
-        <div class="span3 cr-label">
-            <label>
-                <span id="add-consumer-label">Does this complaint involve an additional account holder, card-holder or co-signer?</span> <small class="inline">(Optional)</small>
-                <div class='is-required'>Optional</div>
-            </label>
+        <div class="row cr-question">
+            <fieldset class="cr-fieldset">
+                <div class="span3 cr-label">
+                    <label>
+                        <span id="add-consumer-label">Does this complaint involve an additional account holder, card-holder or co-signer?</span> <small class="inline">(Optional)</small>
+                        <div class='is-required'>Optional</div>
+                    </label>
 
+                </div>
+
+                <div class="span9 cr-answer cr-radios cr-behalf cr-add-con prodselect">
+                    <label class="radio block">
+                        <input type="radio" class='add-consumer-yes' name="add-consumer" value="yes">
+                        Yes
+                    </label>
+
+                    <label class="radio block last">
+                        <input type="radio" class='add-consumer-no' name="add-consumer" value="no">
+                        No
+                    </label>
+                </div>
+            </fieldset>
         </div>
-
-        <div class="span9 cr-answer cr-radios cr-behalf cr-add-con prodselect">
-            <label class="radio block">
-                <input type="radio" class='add-consumer-yes' name="add-consumer" value="yes">
-                Yes
-            </label>
-
-            <label class="radio block last">
-                <input type="radio" class='add-consumer-no' name="add-consumer" value="no">
-                No
-            </label>
-        </div>
-    </fieldset>
-</div>
-<!-- /question -->
+        <!-- /question -->
 
 
-
-
-<fieldset id="consumer2-identity" class="cr-fieldset additional-consumer">
-        <!-- question -->
-
-
-
-                   <div class="row cr-question">
-
-
-
-                 <div class="span3 cr-label cr-question-left">
+        <fieldset id="consumer2-identity" class="cr-fieldset additional-consumer">
+            <!-- question -->
+            <div class="row cr-question">
+                <div class="span3 cr-label cr-question-left">
                     <label for="point-of-contact-identity">
                         This person is...
-                    <div class='is-required'>Answer Required</div>
-                </label>
+                        <div class='is-required'>Answer Required</div>
+                    </label>
 
                     <select name="primary-consumer-identity" id="additional-consumer-identity" class="input-medium">
                         <option>Select an option...</option>
@@ -619,18 +528,12 @@ ADDITIONAL CONSUMER. SAME AS ABOVE CONTENT, MOSTLY
 
                     <p class="ans-poc-other-who-spacer">&nbsp;</p>
                 </div>
+            </div>
+        </fieldset>
 
+        <fieldset class="cr-fieldset additional-consumer full-name-format">
 
-
-         </div>
-
-
-
-    </fieldset>
-
-    <fieldset class="cr-fieldset additional-consumer full-name-format">
-
-   <!-- First name and middle name -->
+            <!-- First name and middle name -->
             <div class="row cr-question ">
                 <div class="span3 cr-label cr-question-left ">
                     <label for="cr-first-name2_4851476384792477">
@@ -646,56 +549,49 @@ ADDITIONAL CONSUMER. SAME AS ABOVE CONTENT, MOSTLY
                     </label>
                     <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477" placeholder="">
                 </div>
-    <!-- /middle name -->
+                <!-- /middle name -->
             </div>
-<!-- /First name and middle name -->
+            <!-- /First name and middle name -->
 
-<!-- Last name and suffix -->
-
-
-                <div class="row cr-question cr-question-last">
+            <!-- Last name and suffix -->
+            <div class="row cr-question cr-question-last">
                 <div class="span3 cr-label cr-question-left">
-                        <label for="cr-last-name2_4851476384792477">
-                            Last name
-                            <div class='is-required'>Answer Required</div>
-                        </label>
+                    <label for="cr-last-name2_4851476384792477">
+                        Last name
+                        <div class='is-required'>Answer Required</div>
+                    </label>
 
-                        <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
-                    </div>
-
-                    <!-- suffix -->
-                    <div class="span2 cr-label cr-question-right">
-                        <label for="cr-suffix2">
-                            Suffix
-                            <small class="inline">(Optional)</small>
-                        </label>
-
-
-                        <select name="cr-suffix" id="cr-suffix2_4851476384792477" class="block">
-                            <option value="" disabled="disabled" selected="selected">Select...</option>
-                            <option value="">Jr</option>
-                            <option value="">Sr</option>
-                            <option value="">PhD</option>
-                            <option value="">DS</option>
-                            <option value="">Esq</option>
-                            <option value="">I</option>
-                            <option value="">II</option>
-                            <option value="">III</option>
-                            <option value="">IV</option>
-                            <option value="">V</option>
-                            <option value="">VI</option>
-                            <option value="">VII</option>
-                            <option value="">IX</option>
-                            <option value="">X</option>
-                        </select>
-
-                    </div>
-                    <!-- /suffix -->
-
-
+                    <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
                 </div>
-                <!-- /city and state -->
-    </fieldset>
+
+                <!-- suffix -->
+                <div class="span2 cr-label cr-question-right">
+                    <label for="cr-suffix2">
+                        Suffix
+                        <small class="inline">(Optional)</small>
+                    </label>
+                    <select name="cr-suffix" id="cr-suffix2_4851476384792477" class="block">
+                        <option value="" disabled="disabled" selected="selected">Select...</option>
+                        <option value="">Jr</option>
+                        <option value="">Sr</option>
+                        <option value="">PhD</option>
+                        <option value="">DS</option>
+                        <option value="">Esq</option>
+                        <option value="">I</option>
+                        <option value="">II</option>
+                        <option value="">III</option>
+                        <option value="">IV</option>
+                        <option value="">V</option>
+                        <option value="">VI</option>
+                        <option value="">VII</option>
+                        <option value="">IX</option>
+                        <option value="">X</option>
+                    </select>
+                </div>
+                <!-- /suffix -->
+            </div>
+            <!-- /city and state -->
+        </fieldset>
 <!--
      <fieldset class="cr-fieldset additional-consumer">
 
@@ -711,58 +607,42 @@ ADDITIONAL CONSUMER. SAME AS ABOVE CONTENT, MOSTLY
                     <p>Your Zip Code can us identify trends in the marketplace</p>
                 </div>
             </div>
-
-
     </fieldset>
 -->
-     <fieldset id="additional-consumer-email" class="cr-fieldset additional-consumer">
+<fieldset id="additional-consumer-email" class="cr-fieldset additional-consumer">
+    <!-- email address -->
+    <div class="cr-question cr-question-last borrower-email additional-consumer-email">
+        <div class="span3 cr-label cr-question-left cr-question-with-checkbox">
+            <label for="con1-email">
+                Email address <small id="addcon-optional-status" class="inline">(Optional)</small>
+                <div class='is-required'>Optional</div>
+            </label>
 
+            <input type="email" name="cr-email2" id="cr-email2_2356852120719850" placeholder="" class="input-large left">
+            <p id="addcon-email-helper">We’ll use this email address to send updates about the status of this complaint. It will also be the additional consumer's username for logging in to their account.</p>
+        </div>
 
+        <div class="span2 cr-label cr-question-right right-helper add-consumer">
+            <label id="cr-add-consumer-checkbox" class="radio block">
+                <input type="checkbox" name="no-email" value="no-email" class="cr-no-email checkbox" id="cr-add-consumer-full">
+                Allow this person to access this complaint and receive status updates.
+            </label>
+        </div>
+    </div>
 
-                <!-- email address -->
-            <div class="cr-question cr-question-last borrower-email additional-consumer-email">
-                    <div class="span3 cr-label cr-question-left cr-question-with-checkbox">
-                        <label for="con1-email">
-                            Email address <small id="addcon-optional-status" class="inline">(Optional)</small>
-                            <div class='is-required'>Optional</div>
-                        </label>
-
-                        <input type="email" name="cr-email2" id="cr-email2_2356852120719850" placeholder="" class="input-large left">
-                        <p id="addcon-email-helper">We’ll use this email address to send updates about the status of this complaint. It will also be the additional consumer's username for logging in to their account.</p>
-                    </div>
-
-                                    <div class="span2 cr-label cr-question-right right-helper add-consumer">
-                                <label id="cr-add-consumer-checkbox" class="radio block">
-                                    <input type="checkbox" name="no-email" value="no-email" class="cr-no-email checkbox" id="cr-add-consumer-full">
-                                     Allow this person to access this complaint and receive status updates.
-                                </label>
-                </div>
-
-            </div>
-
-
-
-                <!-- Zip code -->
-                <div id="addcon-phone-number" class="row cr-question cr-question-last">
-
-
-                    <!-- suffix -->
-                    <div class="span2 cr-label cr-question-left">
-                        <label for="cr-suffix2">
-                            Phone number
-                        </label>
-                    <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477" placeholder="">
-
-
-                </div>
-
-
-                <!-- /zip code  -->
+    <!-- Zip code -->
+    <div id="addcon-phone-number" class="row cr-question cr-question-last">
+        <!-- suffix -->
+        <div class="span2 cr-label cr-question-left">
+            <label for="cr-suffix2">
+                Phone number
+            </label>
+            <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477" placeholder="">
+        </div>
+        <!-- /zip code  -->
     </fieldset>
+</div>
 
-
-
- </div>
 <!--
 
 ///////////////
@@ -770,9 +650,6 @@ END OF Additional Consumer
 ///////////////
 
 -->
-
-
-
 
 <!--
 
@@ -782,161 +659,150 @@ POINT OF CONTACT
 
 -->
 
-
 <div class="cr-primary-container">
-        <h3 id="point-of-contact-header">Additional point of contact</h3>
-<!--        <p>Someone who will communicate on behalf of the primary consumer</p> -->
+    <h3 id="point-of-contact-header">Additional point of contact</h3>
+    <!--    <p>Someone who will communicate on behalf of the primary consumer</p> -->
 
     <fieldset class="cr-fieldset">
         <!-- question -->
-<div class="row cr-question">
-    <fieldset class="cr-fieldset point-of-contact-question">
-        <div class="span3 cr-label">
-            <label>
-                Should we send status updates to anyone else about this complaint? <small class="inline">(Optional)</small>
-                <div class='is-required'>Optional</div>
-            </label>
-
-        </div>
-
-        <div class="span9 cr-answer cr-radios cr-behalf cr-add-poc prodselect">
-            <label class="radio block">
-                <input type="radio" class='add-poc-yes' name="add-poc-no" value="yes">
-                Yes
-            </label>
-
-            <label class="radio block last">
-                <input type="radio" class='add-poc-no' name="add-poc-no" value="no">
-                No
-            </label>
-        </div>
-    </fieldset>
-</div>
-<!-- /question -->
-
-
-
-<fieldset id="poc-relationship-to-consumer" class="cr-fieldset point-of-contact">
-        <!-- question -->
-         <div class="row cr-question">
-
-
-
-                 <div class="span3 cr-label cr-question-left">
-                    <label for="point-of-contact-identity">
-                        Relationship to consumer
-                        <div class='is-required'>Answer Required</div>
+        <div class="row cr-question">
+            <fieldset class="cr-fieldset point-of-contact-question">
+                <div class="span3 cr-label">
+                    <label>
+                        Should we send status updates to anyone else about this complaint? <small class="inline">(Optional)</small>
+                        <div class='is-required'>Optional</div>
                     </label>
 
-                    <select name="point-of-contact-identity" id="point-of-contact-identity" class="input-medium">
-                        <option>Select an option...</option>
-                        <option class="ans-rel-family-member" value="family-member">Family Member</option>
-                        <option class="ans-rel-friend" value="friend">Friend</option>
-                        <option class="ans-rel-attorney" value="attorney">Attorney</option>
-                        <option class="ans-rel-government-employee" value="gov-employee">Government employee</option>
-                        <option class="ans-rel-advocate" value="advocate">Advocate</option>
-                        <option class="ans-rel-housing-counselor" value="housing-counselor">Housing counselor</option>
-                        <option class="ans-rel-other" value="other">Other</option>
-                    </select>
-
-                    <p id="ans-poc-other-who-spacer">&nbsp;</p>
                 </div>
 
-                <div id="poc-access-div" class="span2 cr-label cr-question-right right-helper add-consumer">
-                                <label id="cr-add-consumer-checkbox" class="radio block">
-                                    <input type="checkbox" name="no-email" value="no-email" class="cr-no-email checkbox" id="cr-add-poc-full">
-                                     Allow this person full access to this complaint in addition to status updates.
-                                </label>
+                <div class="span9 cr-answer cr-radios cr-behalf cr-add-poc prodselect">
+                    <label class="radio block">
+                        <input type="radio" class='add-poc-yes' name="add-poc-no" value="yes">
+                        Yes
+                    </label>
+
+                    <label class="radio block last">
+                        <input type="radio" class='add-poc-no' name="add-poc-no" value="no">
+                        No
+                    </label>
                 </div>
+            </fieldset>
+        </div>
+        <!-- /question -->
 
-         </div>
-         <div class="row cr-question">
+        <fieldset id="poc-relationship-to-consumer" class="cr-fieldset point-of-contact">
+           <!-- question -->
+           <div class="row cr-question">
 
-                    <div id="ans-poc-other-who" class="selected_other cr-question cr-label cr-question-left cr-question-last">
-                        <label id="cr-poc-other-who-label" for="cr-poc-other-who">
-                            Organization name
-                        </label>
-                        <input type="text" class="input-medium" name="cr-poc-other-who" id="cr-poc-other-who" placeholder="">
-                    </div>
-         </div>
+               <div class="span3 cr-label cr-question-left">
+                <label for="point-of-contact-identity">
+                    Relationship to consumer
+                    <div class='is-required'>Answer Required</div>
+                </label>
+
+                <select name="point-of-contact-identity" id="point-of-contact-identity" class="input-medium">
+                    <option>Select an option...</option>
+                    <option class="ans-rel-family-member" value="family-member">Family Member</option>
+                    <option class="ans-rel-friend" value="friend">Friend</option>
+                    <option class="ans-rel-attorney" value="attorney">Attorney</option>
+                    <option class="ans-rel-government-employee" value="gov-employee">Government employee</option>
+                    <option class="ans-rel-advocate" value="advocate">Advocate</option>
+                    <option class="ans-rel-housing-counselor" value="housing-counselor">Housing counselor</option>
+                    <option class="ans-rel-other" value="other">Other</option>
+                </select>
+
+                <p id="ans-poc-other-who-spacer">&nbsp;</p>
+            </div>
+
+            <div id="poc-access-div" class="span2 cr-label cr-question-right right-helper add-consumer">
+                <label id="cr-add-consumer-checkbox" class="radio block">
+                    <input type="checkbox" name="no-email" value="no-email" class="cr-no-email checkbox" id="cr-add-poc-full">
+                    Allow this person full access to this complaint in addition to status updates.
+                </label>
+            </div>
+
+        </div>
+        <div class="row cr-question">
+
+            <div id="ans-poc-other-who" class="selected_other cr-question cr-label cr-question-left cr-question-last">
+                <label id="cr-poc-other-who-label" for="cr-poc-other-who">
+                    Organization name
+                </label>
+                <input type="text" class="input-medium" name="cr-poc-other-who" id="cr-poc-other-who" placeholder="">
+            </div>
+        </div>
 
     </fieldset>
 
     <fieldset id="poc-disclosure" class="cr-fieldset">
-         <div class="row cr-question">
+       <div class="row cr-question">
 
-             <p>Allowing full access may require documentation, such as a signed release form. You can include an authorization document as an attachment on the next page.</p>
-         </div>
-    </fieldset>
+           <p>Allowing full access may require documentation, such as a signed release form. You can include an authorization document as an attachment on the next page.</p>
+       </div>
+   </fieldset>
 
-    <fieldset class="cr-fieldset point-of-contact">
+   <fieldset class="cr-fieldset point-of-contact">
 
-   <!-- First name and middle name -->
-            <div class="row cr-question full-name-format">
-                <div class="span3 cr-label cr-question-left ">
-                    <label for="cr-first-name2_4851476384792477">
-                        First name
-                    </label>
-                    <input type="text" name="cr-first-name2" id="cr-first-name2_4851476384792477" placeholder="">
-                </div>
+     <!-- First name and middle name -->
+     <div class="row cr-question full-name-format">
+        <div class="span3 cr-label cr-question-left ">
+            <label for="cr-first-name2_4851476384792477">
+                First name
+            </label>
+            <input type="text" name="cr-first-name2" id="cr-first-name2_4851476384792477" placeholder="">
+        </div>
 
-                <!-- middle name -->
-                <div class="span2 cr-label cr-question-right">
-                    <label for="cr-middle-name2_4851476384792477">
-                        Middle <small class="inline">(Optional)</small>
-                    </label>
-                    <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477" placeholder="">
-                </div>
-    <!-- /middle name -->
-            </div>
-<!-- /First name and middle name -->
+        <!-- middle name -->
+        <div class="span2 cr-label cr-question-right">
+            <label for="cr-middle-name2_4851476384792477">
+                Middle <small class="inline">(Optional)</small>
+            </label>
+            <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477" placeholder="">
+        </div>
+        <!-- /middle name -->
+    </div>
+    <!-- /First name and middle name -->
 
-<!-- Last name and suffix -->
+    <!-- Last name and suffix -->
+    <div class="row cr-question cr-question-last">
+        <div class="span3 cr-label cr-question-left">
+            <label for="cr-last-name2_4851476384792477">
+                Last name
+                <div class='is-required'>Answer Required</div>
+            </label>
 
+            <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
+        </div>
 
-                <div class="row cr-question cr-question-last">
-                <div class="span3 cr-label cr-question-left">
-                        <label for="cr-last-name2_4851476384792477">
-                            Last name
-                            <div class='is-required'>Answer Required</div>
-                        </label>
+        <!-- suffix -->
+        <div class="span2 cr-label cr-question-right">
+            <label for="cr-suffix2">
+                Suffix
+                <small class="inline">(Optional)</small>
+            </label>
+            <select name="cr-suffix" id="cr-suffix2_4851476384792477" class="block">
+                <option value="" disabled="disabled" selected="selected">Select...</option>
+                <option value="">Jr</option>
+                <option value="">Sr</option>
+                <option value="">PhD</option>
+                <option value="">DS</option>
+                <option value="">Esq</option>
+                <option value="">I</option>
+                <option value="">II</option>
+                <option value="">III</option>
+                <option value="">IV</option>
+                <option value="">V</option>
+                <option value="">VI</option>
+                <option value="">VII</option>
+                <option value="">IX</option>
+                <option value="">X</option>
+            </select>
 
-                        <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
-                    </div>
-
-                    <!-- suffix -->
-                    <div class="span2 cr-label cr-question-right">
-                        <label for="cr-suffix2">
-                            Suffix
-                            <small class="inline">(Optional)</small>
-                        </label>
-
-
-                        <select name="cr-suffix" id="cr-suffix2_4851476384792477" class="block">
-                            <option value="" disabled="disabled" selected="selected">Select...</option>
-                            <option value="">Jr</option>
-                            <option value="">Sr</option>
-                            <option value="">PhD</option>
-                            <option value="">DS</option>
-                            <option value="">Esq</option>
-                            <option value="">I</option>
-                            <option value="">II</option>
-                            <option value="">III</option>
-                            <option value="">IV</option>
-                            <option value="">V</option>
-                            <option value="">VI</option>
-                            <option value="">VII</option>
-                            <option value="">IX</option>
-                            <option value="">X</option>
-                        </select>
-
-                    </div>
-                    <!-- /suffix -->
-
-
-                </div>
-                <!-- /city and state -->
-    </fieldset>
+        </div>
+        <!-- /suffix -->
+    </div>
+    <!-- /city and state -->
+</fieldset>
 <!--
      <fieldset class="cr-fieldset point-of-contact">
 
@@ -952,41 +818,33 @@ POINT OF CONTACT
                     <p>Your Zip Code can us identify trends in the marketplace</p>
                 </div>
             </div>
-
-
     </fieldset>
 -->
-     <fieldset id="poc-email-address" class="cr-fieldset point-of-contact">
+<fieldset id="poc-email-address" class="cr-fieldset point-of-contact">
+    <!-- email address -->
+    <div class="cr-question borrower-email">
+        <div class="span3 cr-label cr-question-left cr-question-with-checkbox cr-question-last poc-email-address">
+            <label for="con1-email">
+                Email address
+                <div class='is-required'>Required</div>
+            </label>
 
-
-                <!-- email address -->
-            <div class="cr-question borrower-email">
-                    <div class="span3 cr-label cr-question-left cr-question-with-checkbox cr-question-last poc-email-address">
-                        <label for="con1-email">
-                            Email address
-                            <div class='is-required'>Required</div>
-                        </label>
-
-                        <input type="email" name="cr-email2" id="cr-email2_2356852120719850" placeholder="" class="input-large left">
-                        <p>We’ll use this email address to send updates about the status of this complaint. <span id="poc-email-helper">It will also be the point of contact's username for logging in to their account.</span></p>
-                    </div>
-                    <div class="span2 cr-label cr-question-right right-helper question-checkbox">
+            <input type="email" name="cr-email2" id="cr-email2_2356852120719850" placeholder="" class="input-large left">
+            <p>We’ll use this email address to send updates about the status of this complaint. <span id="poc-email-helper">It will also be the point of contact's username for logging in to their account.</span></p>
+        </div>
+        <div class="span2 cr-label cr-question-right right-helper question-checkbox">
 <!--
                                 <label class="radio block">
                                     <input type="checkbox" name="no-email" value="no-email" class="cr-no-email checkbox" id="cr-no-email">
                                     Allow this person to access this complaint and receive status updates.
                                 </label>
--->
+                            -->
+                        </div>
                     </div>
+                    <!-- /email  -->
 
 
-            </div>
-                <!-- /email  -->
-
-
-
-
-                <!-- email address -->
+                    <!-- email address -->
 <!--
             <div class="cr-question borrower-email cr-question-last normal-checkbox">
                     <div class="span3 cr-label cr-question">
@@ -996,31 +854,21 @@ POINT OF CONTACT
                                     Allow this person to access this complaint and receive status updates.
                                 </label>
                     </div>
-
-
             </div>
--->
-                <!-- /email  -->
+        -->
+        <!-- /email  -->
 
+        <div id="poc-phone-number" class="row cr-question cr-question-last">
+            <!-- suffix -->
+            <div class="span2 cr-label cr-question-left">
+                <label for="cr-suffix2">
+                    Phone number
+                </label>
+                <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477" placeholder="">
+            </div>
 
-
-                <div id="poc-phone-number" class="row cr-question cr-question-last">
-
-
-                    <!-- suffix -->
-                    <div class="span2 cr-label cr-question-left">
-                        <label for="cr-suffix2">
-                            Phone number
-                        </label>
-                    <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477" placeholder="">
-
-
-                </div>
-
-    </fieldset>
- </div>
-
-
+        </fieldset>
+    </div>
 
 <!--
 
@@ -1038,181 +886,150 @@ AFFILIATIONS
 
 -->
 
-
-
-
 <div class="cr-primary-container">
-        <h3 id="affiliations-section">Affiliations</h3>
-        <p>We use this information to help identify trends in the marketplace.</p>
+    <h3 id="affiliations-section">Affiliations</h3>
+    <p>We use this information to help identify trends in the marketplace.</p>
     <fieldset class="cr-fieldset">
 
-                        <!-- question -->
-                        <div id="affiliation-question" class="row cr-question">
+        <!-- question -->
+        <div id="affiliation-question" class="row cr-question">
 
-                            <div class="span3 cr-label">
+            <div class="span3 cr-label">
 
-                                <label for="cr-military-status">
-                                    <span id='military-question'>The primary consumer is:</span>
-                                    <small class="block">(Optional, choose all that apply)</small>
-                                </label>
+                <label for="cr-military-status">
+                    <span id='military-question'>The primary consumer is:</span>
+                    <small class="block">(Optional, choose all that apply)</small>
+                </label>
 
-                            </div>
+            </div>
 
-                            <div id="affiliation-options" class="span9 cr-answer cr-radios cr-servicemember prodselect">
+            <div id="affiliation-options" class="span9 cr-answer cr-radios cr-servicemember prodselect">
 
-                                <label class="radio block">
-                                    <input type="checkbox" name="cr-military-status" value="option1" class="cr-need-military-status" id="cr-military-status">
-                                    A servicemember or veteran
-                                </label>
+                <label class="radio block">
+                    <input type="checkbox" name="cr-military-status" value="option1" class="cr-need-military-status" id="cr-military-status">
+                    A servicemember or veteran
+                </label>
 
-                                <label class="radio block">
-                                    <input type="checkbox" name="cr-military-status2" value="option2" class="cr-need-servicemember-info">
-                                    The spouse or dependent of a servicemember or veteran
-                                </label>
+                <label class="radio block">
+                    <input type="checkbox" name="cr-military-status2" value="option2" class="cr-need-servicemember-info">
+                    The spouse or dependent of a servicemember or veteran
+                </label>
+                <label class="radio block">
+                    <input type="checkbox" name="cr-student" value="option3" class="cr-need-over-62">
+                    A current student
+                    <br/><small>Includes any college or university degree program</small>
+                </label>
 
+                <label class="radio block">
+                    <input type="checkbox" name="cr-justice-involved" value="option3" class="cr-need-over-62">
+                    A person with a disability
+                </label>
+            </div>
 
-                                <label class="radio block">
-                                    <input type="checkbox" name="cr-student" value="option3" class="cr-need-over-62">
-                                    A current student
-                                    <br/><small>Includes any college or university degree program</small>
-                                </label>
+        </div>
+        <!-- /question -->
 
+    </fieldset>
+    <fieldset id="servicemember-details" class="cr-fieldset affiliation-details cr-military-status">
+        <div class="row cr-question ">
 
+            <div class="span3 cr-label cr-question-left ">
+                <label for="cr-first-name2_4851476384792477">
+                    Current status
+                </label>
+                <select name="cr-current-status" id="cr-current-status">
+                    <option value="">Choose...</option>
+                    <option value="">Active</option>
+                    <option value="">Reserve</option>
+                    <option value="">National Guard</option>
+                    <option value="">Retired</option>
+                    <option value="">Veteran</option>
+                </select>
 
-                                <label class="radio block">
-                                    <input type="checkbox" name="cr-justice-involved" value="option3" class="cr-need-over-62">
-                                    A person with a disability
-                                </label>
+            </div>
 
+            <!-- middle name -->
+            <div class="span2 cr-label cr-question-right">
+                <label for="cr-middle-name2_4851476384792477">
+                    Branch of service
+                </label>
+                <select name="cr-military-service" id="cr-military-service" class="block">
+                    <option value="">Choose...</option>
+                    <option value="">Marines</option>
+                    <option value="">Air Force</option>
+                    <option value="">Army</option>
+                    <option value="">Navy</option>
+                    <option value="">Coast Guard</option>
+                    <option value="">Public Health Service</option>
+                    <option value="">National Oceanic and Atmospheric Admin</option>
+                </select>
 
-                            </div>
+            </div>
+            <!-- /middle name -->
+        </div>
 
-                        </div>
-                        <!-- /question -->
+        <div class="row cr-question cr-question-last">
+            <div class="span3 cr-label cr-question-left">
+                <label for="cr-last-name2_4851476384792477">
+                    Rank <small class="inline">(Optional)</small>
+                </label>
 
-                        </fieldset>
-                            <fieldset id="servicemember-details" class="cr-fieldset affiliation-details cr-military-status">
+                <select name="cr-military-rank" id="cr-military-rank">
+                    <option value="">Choose...</option>
+                    <option value="">E1-E4</option>
+                    <option value="">E5-E7</option>
+                    <option value="">E8-E9</option>
+                    <option value="">O1-O3</option>
+                    <option value="">O4-O6</option>
+                    <option value="">O7-O10</option>
+                    <option value="">W01-CW5</option>
+                </select>
 
+            </div>
 
-                                    <div class="row cr-question ">
+            <!-- suffix -->
+            <div class="span2 cr-label cr-question-right">
+                <label for="cr-suffix2">
+                    Military base/location
+                    <small class="inline">(Optional)</small>
+                </label>
+                <select name="cr-suffix" id="cr-suffix2_4851476384792477" class="block">
+                    <option value="" disabled="disabled" selected="selected">Select...</option>
+                    <option value="">Minot Air Force Base</option>
+                    <option value="">McConnell Air Force Base</option>
+                    <option value="">Offutt Air Force Base</option>
+                    <option value="">Maxwell Air Force Base</option>
+                    <option value="">McClellan Air Force Base</option>
+                    <option value="">Fairchild Air Force Base</option>
+                </select>
 
-
-
-
-
-                                        <div class="span3 cr-label cr-question-left ">
-                                            <label for="cr-first-name2_4851476384792477">
-                                                Current status
-                                            </label>
-                                            <select name="cr-current-status" id="cr-current-status">
-                                                <option value="">Choose...</option>
-                                                <option value="">Active</option>
-                                                <option value="">Reserve</option>
-                                                <option value="">National Guard</option>
-                                                <option value="">Retired</option>
-                                                <option value="">Veteran</option>
-                                            </select>
-
-                                        </div>
-
-                                            <!-- middle name -->
-                                        <div class="span2 cr-label cr-question-right">
-                                            <label for="cr-middle-name2_4851476384792477">
-                                                Branch of service
-                                            </label>
-                                            <select name="cr-military-service" id="cr-military-service" class="block">
-                                                <option value="">Choose...</option>
-                                                <option value="">Marines</option>
-                                                <option value="">Air Force</option>
-                                                <option value="">Army</option>
-                                                <option value="">Navy</option>
-                                                <option value="">Coast Guard</option>
-                                                <option value="">Public Health Service</option>
-                                                <option value="">National Oceanic and Atmospheric Admin</option>
-                                            </select>
-
-                                        </div>
-                                            <!-- /middle name -->
-                                    </div>
-
-
-
-                                        <div class="row cr-question cr-question-last">
-                                        <div class="span3 cr-label cr-question-left">
-                                                <label for="cr-last-name2_4851476384792477">
-                                                    Rank <small class="inline">(Optional)</small>
-                                                </label>
-
-                                                <select name="cr-military-rank" id="cr-military-rank">
-                                                    <option value="">Choose...</option>
-                                                    <option value="">E1-E4</option>
-                                                    <option value="">E5-E7</option>
-                                                    <option value="">E8-E9</option>
-                                                    <option value="">O1-O3</option>
-                                                    <option value="">O4-O6</option>
-                                                    <option value="">O7-O10</option>
-                                                    <option value="">W01-CW5</option>
-                                                </select>
-
-                                            </div>
-
-                                            <!-- suffix -->
-                                            <div class="span2 cr-label cr-question-right">
-                                                <label for="cr-suffix2">
-                                                    Military base/location
-                                                    <small class="inline">(Optional)</small>
-                                                </label>
-
-
-                                                <select name="cr-suffix" id="cr-suffix2_4851476384792477" class="block">
-                                                    <option value="" disabled="disabled" selected="selected">Select...</option>
-                                                    <option value="">Minot Air Force Base</option>
-                                                    <option value="">McConnell Air Force Base</option>
-                                                    <option value="">Offutt Air Force Base</option>
-                                                    <option value="">Maxwell Air Force Base</option>
-                                                    <option value="">McClellan Air Force Base</option>
-                                                    <option value="">Fairchild Air Force Base</option>
-                                                </select>
-
-                                            </div>
-                                            <!-- /suffix -->
-
-
-                                        </div>
-                                        <!-- /city and state -->
-                            </fieldset>
-
-
+            </div>
+            <!-- /suffix -->
+        </div>
+        <!-- /city and state -->
+    </fieldset>
 
 
 </div>
 
 
 
-
-
-
-
-            </div>
-            <!-- /.primary -->
-
-
+</div>
+<!-- /.primary -->
 <!-- options below form -->
 <div class="row cr-continue">
   <a id="continue-button" href="review-and-submit.html"><button class="btn btn-arrow" type="button">Continue</button></a>
   <a id="save-and-continue-later-link" href="#">Save and continue later</a>
 </div>
 <!-- /options below form -->
-
-
-        </section>
-        <!-- /.row -->
+</section>
+<!-- /.row -->
 
 <!-- =============
      / END CONTENT
      ============= -->
 
-    </div><!-- .wrapper-container -->
+ </div><!-- .wrapper-container -->
 
 </div><!-- .wrapper-body -->
 
@@ -1246,10 +1063,10 @@ AFFILIATIONS
 
 <!-- TODO: Remove inline styling and scripting. -->
 <style type="text/css">
-.brand h1 {
-    background: transparent url(v0/form/img/money_@2_alt.png) scroll no-repeat left center;
-    background-size:46px;
-}
+    .brand h1 {
+        background: transparent url(v0/form/img/money_@2_alt.png) scroll no-repeat left center;
+        background-size:46px;
+    }
 </style>
 
 <div id='_cur'>
@@ -1257,27 +1074,27 @@ AFFILIATIONS
 </div>
 
 <style type="text/css">
-#_cur{
-    position:absolute;
-    top:0px;
-    left:0px;
-    z-index:100000;
-    width:10px;
-    height:10px;
-    margin-left: -8px;
-    margin-top: -8px;
-    left: -10px;
-    top:-10px;
-    background:transparent;
-    opacity:.9;
-    border-radius:100%;
-    border:4px solid rgba(255,255,255,.6);
-}
+    #_cur{
+        position:absolute;
+        top:0px;
+        left:0px;
+        z-index:100000;
+        width:10px;
+        height:10px;
+        margin-left: -8px;
+        margin-top: -8px;
+        left: -10px;
+        top:-10px;
+        background:transparent;
+        opacity:.9;
+        border-radius:100%;
+        border:4px solid rgba(255,255,255,.6);
+    }
 
-#_cur.clk{
-    border:4px dotted black;
-    background: transparent;
-}
+    #_cur.clk{
+        border:4px dotted black;
+        background: transparent;
+    }
 </style>
 
 <script type="text/javascript">
@@ -1287,15 +1104,15 @@ AFFILIATIONS
 
 <script>
 
-if(!window.env){
-    setTimeout(function(){
-        var product = localStorage.getItem("product_selected");
-        var subproduct = localStorage.getItem("subproduct_selected");
-        var issue = localStorage.getItem("issue_selected");
-/*         alert(product + ', ' + subproduct + ', ' + issue); */
-        switch (product) {
+    if(!window.env){
+        setTimeout(function(){
+            var product = localStorage.getItem("product_selected");
+            var subproduct = localStorage.getItem("subproduct_selected");
+            var issue = localStorage.getItem("issue_selected");
+            /*         alert(product + ', ' + subproduct + ', ' + issue); */
+            switch (product) {
 
-            case 'mortgage':
+                case 'mortgage':
                 $('#primary-consumer-identity-option1').text('Primary borrower');
                 $('#primary-consumer-identity-option2').text('Co-borrower');
                 $('#primary-consumer-identity-option3').text('Co-signer');
@@ -1306,7 +1123,7 @@ if(!window.env){
                 $('#additional-consumer-identity-option4').remove();
                 break;
 
-            case 'student_loan':
+                case 'student_loan':
                 $('#primary-consumer-identity-option1').text('Primary borrower');
                 $('#primary-consumer-identity-option2').text('Co-borrower');
                 $('#primary-consumer-identity-option3').text('Co-signer');
@@ -1317,7 +1134,7 @@ if(!window.env){
                 $('#additional-consumer-identity-option4').remove();
                 break
 
-            case 'vehicle_loan':
+                case 'vehicle_loan':
                 $('#primary-consumer-identity-option1').text('Primary borrower');
                 $('#primary-consumer-identity-option2').text('Co-borrower');
                 $('#primary-consumer-identity-option3').text('Co-signer');
@@ -1329,7 +1146,7 @@ if(!window.env){
                 // NOTE THAT THIS DOES NOT WORK FOR LEASES !!
                 break
 
-            case 'consumer_loan':
+                case 'consumer_loan':
                 $('#primary-consumer-identity-option1').text('Primary borrower');
                 $('#primary-consumer-identity-option2').text('Co-borrower');
                 $('#primary-consumer-identity-option3').text('Co-signer');
@@ -1340,7 +1157,7 @@ if(!window.env){
                 $('#additional-consumer-identity-option4').remove();
                 break
 
-            case 'card':
+                case 'card':
                 $('#primary-consumer-identity-option1').text('Primary account holder');
                 $('#primary-consumer-identity-option2').text('Joint account holder');
                 $('#primary-consumer-identity-option3').text('Additional card holder');
@@ -1351,7 +1168,7 @@ if(!window.env){
                 $('#additional-consumer-identity-option4').remove();
                 break
 
-            case 'checking':
+                case 'checking':
                 $('#primary-consumer-identity-option1').text('Primary account holder');
                 $('#primary-consumer-identity-option2').text('Joint account holder');
                 $('#primary-consumer-identity-option3').remove();
@@ -1362,17 +1179,17 @@ if(!window.env){
                 $('#additional-consumer-identity-option4').remove();
                 break
 
-            case 'credit_reporting':
+                case 'credit_reporting':
                 $('#consumer1-identity').hide();
                 $('#consumer2-identity').remove();
                 break
 
-            case 'debt':
+                case 'debt':
                 $('#consumer1-identity').hide();
                 $('#consumer2-identity').remove();
                 break
 
-            default:
+                default:
                 $('#primary-consumer-identity-option1').text('Primary account holder');
                 $('#primary-consumer-identity-option2').text('Additional account holder');
                 $('#primary-consumer-identity-option3').text('Joint account holder');
@@ -1381,11 +1198,11 @@ if(!window.env){
                 $('#primary-consumer-identity-option6').text('Co-borrower');
                 $('#primary-consumer-identity-option7').text('Sender');
                 $('#primary-consumer-identity-option8').text('Recipient');
-        }
+            }
 
-        switch (subproduct) {
+            switch (subproduct) {
 
-            case 'vehicle-lease':
+                case 'vehicle-lease':
                 $('#primary-consumer-identity-option1').text('Primary account holder');
                 $('#primary-consumer-identity-option2').text('Joint account holder');
                 $('#primary-consumer-identity-option3').text('Co-signer');
@@ -1396,7 +1213,7 @@ if(!window.env){
                 $('#additional-consumer-identity-option4').remove();
                 break
 
-            case 'international-money-transfer':
+                case 'international-money-transfer':
                 $('#primary-consumer-identity-option1').text('Sender');
                 $('#primary-consumer-identity-option2').text('Recipient');
                 $('#primary-consumer-identity-option3').remove();
@@ -1409,7 +1226,7 @@ if(!window.env){
                 $('#consumer1-identity').show().slideDown();
                 break
 
-            case 'domestic-money-transfer':
+                case 'domestic-money-transfer':
                 $('#primary-consumer-identity-option1').text('Sender');
                 $('#primary-consumer-identity-option2').text('Recipient');
                 $('#primary-consumer-identity-option3').remove();
@@ -1422,53 +1239,53 @@ if(!window.env){
                 $('#consumer1-identity').show().slideDown();
                 break
 
-            case 'check-cashing':
+                case 'check-cashing':
                 $('#consumer1-identity').hide();
                 $('#consumer2-identity').remove();
                 break
 
-            case 'money-order':
+                case 'money-order':
                 $('#consumer1-identity').hide();
                 $('#consumer2-identity').remove();
                 break
 
-            case 'mobile-wallet':
+                case 'mobile-wallet':
                 $('#consumer1-identity').hide();
                 $('#additional-consumer-identity-option1').text('Primary account holder');
                 $('#additional-consumer-identity-option2').text('Joint account holder');
                 $('#additional-consumer-identity-option4').text('Recipient');
                 break
 
-            case 'refund-anticipation':
+                case 'refund-anticipation':
                 $('#consumer1-identity').hide();
                 $('#consumer2-identity').remove();
                 break
 
-            case 'traveler-or-cashier':
+                case 'traveler-or-cashier':
                 $('#consumer1-identity').hide();
                 $('#consumer2-identity').remove();
                 break
 
-            case 'virtual-currency':
+                case 'virtual-currency':
                 $('#consumer1-identity').hide();
                 $('#consumer2-identity').remove();
                 break
 
-            case 'debt-settlement':
+                case 'debt-settlement':
                 $('#consumer1-identity').hide();
                 $('#consumer2-identity').remove();
                 break
 
-            default:
+                default:
                 $('#consumer1-identity').hide();
 
-       }
+            }
 
 /*
         if ( $('.company-name-input').val()) {
         $(this).closest('.identify-product-options').slideDown(200);
         }
-*/
+        */
 
     }, 11);
 }


### PR DESCRIPTION
Stop two-column input lists with an odd number of items from spilling into a third column

## Removals

- Get rid of the `float` on input list items to always keep those lists to two columns
- Get rid of an extra `</div>` in `your-information.html` to stop parts of the page from overflowing the page margins

## Testing

- `gulp build`
- Start a local python simple server
- No two-column input lists should run over into three columns
- Step 5 should look like the screenshot below

## Review

- @anselmbradford 

## Screenshots

Two-column lists with an odd number of items should stay in two columns:

Product list, old | Product list, new
----------------- | -----------------
![1-before](https://cloud.githubusercontent.com/assets/1862695/15686715/9d238c3c-273f-11e6-9f8f-af15dba747ad.png) | ![1-after](https://cloud.githubusercontent.com/assets/1862695/15686721/a08e6838-273f-11e6-805d-256295ebe4b9.png)

Everything in step 5 should stay within the page margins:

Step 5, old | Step 5, new
----------- | -----------
![5-before](https://cloud.githubusercontent.com/assets/1862695/15686734/a78e0e54-273f-11e6-9e51-7c6428318b57.png) | ![5-after](https://cloud.githubusercontent.com/assets/1862695/15686738/aafdcebc-273f-11e6-94f8-8b8db4f8e616.png)