### PR TITLE
Add phone number field for unknown companies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Updated eslint to 2.0.0.
 - Normalized gulp variable and task naming.
 - Moved form markup to `/src/`.
+- Capital Framework project infrastructure (including a gulp build)
+- Old prototype files into new Capital Framework structure (temporarily; the old code will be phased out as it is iteratively replaced with new code)
+- Installation and usage instructions to the readme
+- Phone number field to the form that appears when a matching company isn't found in the system in step 4
 
 ### Deprecated
 - Nothing.

--- a/src/company-information.html
+++ b/src/company-information.html
@@ -5,144 +5,134 @@
 <!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
 <head>
 
-<meta charset="utf-8">
+    <meta charset="utf-8">
 
-<title>Submit a complaint | Company information</title>
+    <title>Submit a complaint | Company information</title>
 
-<meta name="description" content="">
-<meta name="viewport" content="width=device-width">
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width">
 
-<link rel="stylesheet" href="v0/form/css/normalize.css">
-<link rel="stylesheet" href="v0/form/css/grid.css">
-<link rel="stylesheet" href="v0/form/css/fonts.css">
-<link rel="stylesheet" href="v0/form/css/new-core.css">
-<link rel="stylesheet" href="v0/form/css/complain.css">
-<link rel="stylesheet" href="v0/form/css/typeahead.css">
-<!-- <link rel="stylesheet" href="v0/form/css/responsive.css"> -->
+    <link rel="stylesheet" href="v0/form/css/normalize.css">
+    <link rel="stylesheet" href="v0/form/css/grid.css">
+    <link rel="stylesheet" href="v0/form/css/fonts.css">
+    <link rel="stylesheet" href="v0/form/css/new-core.css">
+    <link rel="stylesheet" href="v0/form/css/complain.css">
+    <link rel="stylesheet" href="v0/form/css/typeahead.css">
+    <!-- <link rel="stylesheet" href="v0/form/css/responsive.css"> -->
 
-<!-- Custom modernizr for touch detection only, see the .js file for the build link -->
-<script src="v0/form/js/vendor/modernizr.custom.js"></script>
-<script src="v0/form/js/vendor/bootstrap-modal.js"></script>
+    <!-- Custom modernizr for touch detection only, see the .js file for the build link -->
+    <script src="v0/form/js/vendor/modernizr.custom.js"></script>
+    <script src="v0/form/js/vendor/bootstrap-modal.js"></script>
 
-<!--
-    Old IE polyfills for:
-    - HTML5 tags
-    - Media queries (so we can style mobile first)
--->
-<!--[if lt IE 9]>
-<script src="v0/form/js/vendor/html5shim.js"></script>
-<script src="v0/form/js/vendor/respond.min.js"></script>
-<![endif]-->
+    <!--
+        Old IE polyfills for:
+        - HTML5 tags
+        - Media queries (so we can style mobile first)
+    -->
+    <!--[if lt IE 9]>
+    <script src="v0/form/js/vendor/html5shim.js"></script>
+    <script src="v0/form/js/vendor/respond.min.js"></script>
+    <![endif]-->
 
 </head>
 <body class="companyinfo cruxform">
 
-<div class="wrapper-banner" style="font-size: 16px;">
-    <div class="wrapper-container">
-        <small class="split">
-            <span class="official-website">An official website of the United States Government</span>
-        </small>
-    </div>
-</div><!-- .wrapper-banner -->
+    <div class="wrapper-banner" style="font-size: 16px;">
+        <div class="wrapper-container">
+            <small class="split">
+                <span class="official-website">An official website of the United States Government</span>
+            </small>
+        </div>
+    </div><!-- .wrapper-banner -->
 
-<header class="wrapper-header">
+    <header class="wrapper-header">
 
-    <div class="wrapper-container">
+        <div class="wrapper-container">
 
-        <div class="brand">
+            <div class="brand">
 
-            <h1> Submit a complaint</h1>
+                <h1> Submit a complaint</h1>
 
-            <a class="brand-logo" href="https://consumerfinance.gov"><img src="v0/form/img/logo-cfpb-retina.png" alt="Consumer Financial Protection Bureau"></a>
+                <a class="brand-logo" href="https://consumerfinance.gov"><img src="v0/form/img/logo-cfpb-retina.png" alt="Consumer Financial Protection Bureau"></a>
 
-        </div><!-- .brand -->
+            </div><!-- .brand -->
 
-    </div><!-- .wrapper-container -->
+        </div><!-- .wrapper-container -->
 
-</header><!-- .wrapper-header -->
+    </header><!-- .wrapper-header -->
 
-<noscript>
-    For full functionality of this application, it is necessary to enable JavaScript.
-    Here are the <a href="http://www.enable-javascript.com/" target="_blank">
-    instructions how to enable JavaScript in your web browser</a>.
-</noscript>
+    <noscript>
+        For full functionality of this application, it is necessary to enable JavaScript.
+        Here are the <a href="http://www.enable-javascript.com/" target="_blank">
+        instructions how to enable JavaScript in your web browser</a>.
+    </noscript>
+    <div class="wrapper-body page-step-1">
+        <!-- ANNOTATIONS SIDEBAR -->
 
+        <div id="annotations-sidebar">
+            <p id="annotations-opener"><a href="#">Open annotations</a></p>
 
-<div class="wrapper-body page-step-1">
+            <p id="annotations-toggle" class="opened"><a href="#">Toggle annotations</a></p>
 
+            <ul id="annotations-list">
+                <li class="annotation-format">
+                    <h3 class="anno-title">Title of annotation</h3>
+                    <!--                            <h6 class="anno-date">Date added</h6> -->
+                    <p class="anno-link-text"><a class="anno-link" href="#">Link to element</a></p>
+                    <div class="anno-comment">Placeholder text</div>
+                </li>
+            </ul>
 
-<!-- ANNOTATIONS SIDEBAR -->
+        </div>
 
-                <div id="annotations-sidebar">
-                <p id="annotations-opener"><a href="#">Open annotations</a></p>
-
-                <p id="annotations-toggle" class="opened"><a href="#">Toggle annotations</a></p>
-
-                    <ul id="annotations-list">
-                        <li class="annotation-format">
-                            <h3 class="anno-title">Title of annotation</h3>
-<!--                            <h6 class="anno-date">Date added</h6> -->
-                            <p class="anno-link-text"><a class="anno-link" href="#">Link to element</a></p>
-                            <div class="anno-comment">Placeholder text</div>
-                        </li>
-                    </ul>
-
-                </div>
-
-<!-- END OF ANNOTATIONS SIDEBAR -->
-
-
-    <div class="wrapper-container">
+        <!-- END OF ANNOTATIONS SIDEBAR -->
+        <div class="wrapper-container">
 
 <!-- =============
      BEGIN CONTENT
      ============= -->
 
-       <section class="content row cr-content">
+     <section class="content row cr-content">
 
-            <!-- nav on the left side of the page -->
-            <nav class="span4 cr-steps secondary">
-                <!-- uses bootstrap's affix plugin -->
-                <div id="sticky-nav">
-                    <ul>
+        <!-- nav on the left side of the page -->
+        <nav class="span4 cr-steps secondary">
+            <!-- uses bootstrap's affix plugin -->
+            <div id="sticky-nav">
+                <ul>
+                    <li class="incomplete"><a href="select-product.html">1</span></a></li>
 
+                    <li class="incomplete"><a href="select-issue.html">2</a></li>
 
-                            <li class="incomplete"><a href="select-product.html">1</span></a></li>
+                    <li class="incomplete"><a href="what-happened.html">3</a></li>
 
-                            <li class="incomplete"><a href="select-issue.html">2</a></li>
+                    <li class="active incomplete"><a href="company-information.html">4</span></a></li>
 
-                            <li class="incomplete"><a href="what-happened.html">3</a></li>
+                    <li class="incomplete"><a href="your-information.html">5</a></li>
 
-                            <li class="active incomplete"><a href="company-information.html">4</span></a></li>
+                    <li class="incomplete"><a href="review-and-submit.html">6</a></li>
 
-                            <li class="incomplete"><a href="your-information.html">5</a></li>
+                </ul>
 
-                            <li class="incomplete"><a href="review-and-submit.html">6</a></li>
+                <!--                     <a href="#" id="chat-now">Form trouble? Chat now.</a> -->
 
-                    </ul>
+            </div>
+            <!-- /#sticky-nav -->
 
-<!--                     <a href="#" id="chat-now">Form trouble? Chat now.</a> -->
+        </nav>
+        <!-- /nav on the left side of the page -->
 
-                </div>
-                <!-- /#sticky-nav -->
+        <div class="span8 cr-primary">
+            <!-- .error-panel -->
 
-            </nav>
-            <!-- /nav on the left side of the page -->
+            <!-- end .error-panel -->
 
-<div class="span8 cr-primary">
-                <!-- .error-panel -->
+            <div style="text-align: right; margin-top: 30px; margin-right: 30px;">
+              Have a question or need for help? <a>Chat Now</a>
+          </div>
 
-                <!-- end .error-panel -->
-
-                <div style="text-align: right; margin-top: 30px; margin-right: 30px;">
-                  Have a question or need for help? <a>Chat Now</a>
-                </div>
-
-  <div id="select_product" class="cr-primary-container">
-    <h2>What companies are involved?</h2>
-    <p class="page-intro company-info">Identify the the company or companies that this complaint is about. We'll forward your complaint and request a response within 15 days.</p>
-
-
+          <div id="select_product" class="cr-primary-container">
+            <h2>What companies are involved?</h2>
+            <p class="page-intro company-info">Identify the the company or companies that this complaint is about. We'll forward your complaint and request a response within 15 days.</p>
 
 <!--
 ///////////
@@ -152,79 +142,67 @@ COMPANY-1
 
 <div id="company-type-1" class="company-type">
 
-<h3 id="company-intro-1" class="company-intro">Company information</h3>
+    <h3 id="company-intro-1" class="company-intro">Company information</h3>
 
-     <fieldset id="company-name-fieldset-1" class="cr-fieldset">
+    <fieldset id="company-name-fieldset-1" class="cr-fieldset">
         <!-- question -->
-         <div class="row cr-question">
+        <div class="row cr-question">
 
+            <div class="cr-question borrower-email cr-question-last">
+                <div class="span3 cr-label cr-question-left cr-question-with-checkbox">
+                    <label class="autocomplete-company-name" for="company-1">
+                        Company name
+                        <div class='is-required'>Answer Required</div>
+                    </label>
 
-
-        <div class="cr-question borrower-email cr-question-last">
-                    <div class="span3 cr-label cr-question-left cr-question-with-checkbox">
-                        <label class="autocomplete-company-name" for="company-1">
-                            Company name
-                            <div class='is-required'>Answer Required</div>
-                        </label>
-
-                        <input type="company1-name" name="company1-name" id="company1-name" placeholder="" class="input-large company-name-input left">
-                        <div id="forward-company1" class="forward-company-details"><p>We will forward your complaint to this company and ask for a response.</p><div>
+                    <input type="company1-name" name="company1-name" id="company1-name" placeholder="" class="input-large company-name-input left">
+                    <div id="forward-company1" class="forward-company-details"><p>We will forward your complaint to this company and ask for a response.</p><div>
                     </div>
                     <div class="span2 cr-label cr-question-right right-helper question-checkbox company-1-checkbox">
-                                <label class="radio block">
-                                    <input type="checkbox" name="company-unknown" value="company-unknown" class="cr-company-unknown checkbox" id="company-unknown">
-                                    I don't know the company name
-                                </label>
+                        <label class="radio block">
+                            <input type="checkbox" name="company-unknown" value="company-unknown" class="cr-company-unknown checkbox" id="company-unknown">
+                            I don't know the company name
+                        </label>
                     </div>
+                </div>
             </div>
+        </fieldset>
 
-
-          </div>
-    </fieldset>
-
-    <fieldset id="company1-not-boarded" class="cr-fieldset company-not-boarded-info">
+        <fieldset id="company1-not-boarded" class="cr-fieldset company-not-boarded-info">
 
             <div class="row cr-question">
 
-                    <h3>Currently, this company isn’t signed up to receive complaints through our system</h3>
+                <h3>Currently, this company isn’t signed up to receive complaints through our system</h3>
 
-                    <p>We are continuously adding new companies to our system. However, the company you searched for has not yet signed up to receive complaints. Please provide as much information as possible so that we can contact the company and send them your complaint.</p><p>If we find that another government agency would be better able to assist, we will forward your complaint and let you know.</p>
+                <p>We are continuously adding new companies to our system. However, the company you searched for has not yet signed up to receive complaints. Please provide as much information as possible so that we can contact the company and send them your complaint.</p><p>If we find that another government agency would be better able to assist, we will forward your complaint and let you know.</p>
 
-
-
-             <div class="row cr-question ">
-                <div class="span3 cr-label cr-question-with-checkbox">
-                    <label for="cr-first-name2_4851476384792477">
-                        Other names
-                    </label>
-                    <input type="text" name="cr-first-name2" id="cr-first-name2_4851476384792477" placeholder="">
+                <div class="row cr-question ">
+                    <div class="span3 cr-label cr-question-with-checkbox">
+                        <label for="cr-first-name2_4851476384792477">
+                            Other names
+                        </label>
+                        <input type="text" name="cr-first-name2" id="cr-first-name2_4851476384792477" placeholder="">
+                    </div>
                 </div>
 
 
-            </div>
+                <div class="row cr-question ">
+                    <div class="span3 cr-label cr-question-left ">
+                        <label for="cr-first-name2_4851476384792477">
+                            Company address
+                        </label>
+                        <input type="text" name="cr-first-name2" id="cr-first-name2_4851476384792477" placeholder="">
+                    </div>
 
-
-
-
-                    <div class="row cr-question ">
-                <div class="span3 cr-label cr-question-left ">
-                    <label for="cr-first-name2_4851476384792477">
-                        Company address
-                    </label>
-                    <input type="text" name="cr-first-name2" id="cr-first-name2_4851476384792477" placeholder="">
+                    <div class="span2 cr-label cr-question-right">
+                        <label for="cr-middle-name2_4851476384792477">
+                            City
+                        </label>
+                        <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477" placeholder="">
+                    </div>
                 </div>
-
-                <div class="span2 cr-label cr-question-right">
-                    <label for="cr-middle-name2_4851476384792477">
-                        City
-                    </label>
-                    <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477" placeholder="">
-                </div>
-            </div>
-
-
                 <div class="row cr-question cr-question">
-                <div class="span3 cr-label cr-question-left">
+                    <div class="span3 cr-label cr-question-left">
                         <label for="cr-last-name2_4851476384792477">
                             Address line 2 <small class="inline">(Optional)</small>
                             <div class='is-required'>Answer Required</div>
@@ -239,55 +217,49 @@ COMPANY-1
                             State
                             <small class="inline"></small>
                         </label>
-
-
                         <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
-
-
                     </div>
                     <!-- /suffix -->
-
-
                 </div>
                 <!-- /city and state -->
-
-
-             <div class="row cr-question ">
-                <div class="span3 cr-label cr-question-with-checkbox">
-                    <label for="cr-first-name2_4851476384792477">
-                        Website
-                    </label>
-                    <input type="text" name="cr-first-name2" id="cr-first-name2_4851476384792477" placeholder="">
+                <div class="row cr-question">
+                    <div class="span3 cr-label cr-question-left">
+                        <label for="cr-first-name2_4851476384792477">
+                            Website
+                        </label>
+                        <input type="text" name="cr-first-name2" id="cr-first-name2_4851476384792477" placeholder="">
+                    </div>
+                    <div class="span2 cr-label cr-question-right">
+                        <label for="cr-company-phone-1">
+                            Phone number
+                        </label>
+                        <input type="text" name="cr-company-phone-1" id="cr-company-phone-1">
+                    </div>
                 </div>
 
+                <div class="row cr-question-last">
+                    <div class="span3 cr-label cr-question">
+                        <label for="cr-first-name2_4851476384792477">
+                           Other identifying characteristics
+                       </label>
+                       <textarea name="cr-other-identifying" id="cr-first-name2_4851476384792477" rows="4" columns="30" maxlength="4000" placeholder=""></textarea>
+                       <p>Include any details that can help us identify the company, such as the names of company representatives, locations of store branches, and descriptions of branding and advertising.</p>
+                   </div>
+               </div>
 
-             <div class="row cr-question-last">
-                <div class="span3 cr-label cr-question">
-                    <label for="cr-first-name2_4851476384792477">
-                     Other identifying characteristics
-                    </label>
-                    <textarea name="cr-other-identifying" id="cr-first-name2_4851476384792477" rows="4" columns="30" maxlength="4000" placeholder=""></textarea>
-                    <p>Include any details that can help us identify the company, such as the names of company representatives, locations of store branches, and descriptions of branding and advertising.</p>
-                </div>
+           </div>
 
+       </fieldset><!-- not-boarded -->
 
-            </div>
+       <!-- THIS IS WHERE THE OPTIONS GO! -->
 
-            </div>
-
-    </fieldset><!-- not-boarded -->
-
-<!-- THIS IS WHERE THE OPTIONS GO! -->
-
-  </div> <!-- company-type 1 -->
+   </div> <!-- company-type 1 -->
 
 <!--
 ///////////
 End company-1
 ///////////
 -->
-
-
 
 
 <!--
@@ -301,61 +273,51 @@ COMPANY-2
 
 <div id="company-type-2" class="company-type">
 
-<h3 id="company-intro-2" class="company-intro">Company information</h3>
+    <h3 id="company-intro-2" class="company-intro">Company information</h3>
 
-     <fieldset id="company-name-fieldset-2" class="cr-fieldset">
+    <fieldset id="company-name-fieldset-2" class="cr-fieldset">
         <!-- question -->
-         <div class="row cr-question">
+        <div class="row cr-question">
 
+            <div class="cr-question borrower-email cr-question-last">
+                <div class="span3 cr-label cr-question-left cr-question-with-checkbox">
+                    <label class="autocomplete-company-name" for="company-2">
+                        Company name
+                        <div class='is-required'>Answer Required</div>
+                    </label>
 
-
-        <div class="cr-question borrower-email cr-question-last">
-                    <div class="span3 cr-label cr-question-left cr-question-with-checkbox">
-                        <label class="autocomplete-company-name" for="company-2">
-                            Company name
-                            <div class='is-required'>Answer Required</div>
-                        </label>
-
-                        <input type="company2-name" name="company2-name" id="company2-name" placeholder="" class="input-large left company-name-input">
-                        <p id="forward-company2" class="forward-company-details">We will forward your complaint to this company and ask for a response.</p>
-                    </div>
-                    <div class="span2 cr-label cr-question-right right-helper question-checkbox company-2-checkbox additional-company-checkbox">
-                                <label class="radio block">
-                                    <input id="company2-forward" type="checkbox" name="company-unknown" value="company-unknown" class="cr-company-unknown checkbox" >
-                                    This company should also receive and respond to this complaint.
-                                </label>
-                    </div>
+                    <input type="company2-name" name="company2-name" id="company2-name" placeholder="" class="input-large left company-name-input">
+                    <p id="forward-company2" class="forward-company-details">We will forward your complaint to this company and ask for a response.</p>
+                </div>
+                <div class="span2 cr-label cr-question-right right-helper question-checkbox company-2-checkbox additional-company-checkbox">
+                    <label class="radio block">
+                        <input id="company2-forward" type="checkbox" name="company-unknown" value="company-unknown" class="cr-company-unknown checkbox" >
+                        This company should also receive and respond to this complaint.
+                    </label>
+                </div>
             </div>
-
-
-          </div>
+        </div>
     </fieldset>
 
     <fieldset id="company2-not-boarded" class="cr-fieldset company-not-boarded-info">
 
-            <div class="row cr-question">
+        <div class="row cr-question">
 
-                    <h3>This company is not in our complaint system</h3>
+            <h3>This company is not in our complaint system</h3>
 
-                    <p>This company is not currently in our system for receiving complaints. Please provide as much information as possible so that we can contact the company and send them your complaint.</p><p>If we find that another government agency would be better able to assist, we will forward your complaint and let you know.</p>
+            <p>This company is not currently in our system for receiving complaints. Please provide as much information as possible so that we can contact the company and send them your complaint.</p><p>If we find that another government agency would be better able to assist, we will forward your complaint and let you know.</p>
 
-
-
-             <div class="row cr-question ">
+            <div class="row cr-question ">
                 <div class="span3 cr-label cr-question-with-checkbox">
                     <label for="cr-first-name2_4851476384792477">
                         Other names
                     </label>
                     <input type="text" name="cr-first-name2" id="cr-first-name2_4851476384792477" placeholder="">
                 </div>
-
-
             </div>
 
 
-
-
-                    <div class="row cr-question ">
+            <div class="row cr-question ">
                 <div class="span3 cr-label cr-question-left ">
                     <label for="cr-first-name2_4851476384792477">
                         Company address
@@ -370,80 +332,66 @@ COMPANY-2
                     <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477" placeholder="">
                 </div>
             </div>
-
-
-                <div class="row cr-question cr-question">
+            <div class="row cr-question cr-question">
                 <div class="span3 cr-label cr-question-left">
-                        <label for="cr-last-name2_4851476384792477">
-                            Address line 2 <small class="inline">(Optional)</small>
-                            <div class='is-required'>Answer Required</div>
-                        </label>
+                    <label for="cr-last-name2_4851476384792477">
+                        Address line 2 <small class="inline">(Optional)</small>
+                        <div class='is-required'>Answer Required</div>
+                    </label>
 
-                        <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
-                    </div>
-
-                    <!-- suffix -->
-                    <div class="span2 cr-label cr-question-right">
-                        <label for="cr-suffix2">
-                            State
-                            <small class="inline"></small>
-                        </label>
-
-
-                        <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
-
-
-                    </div>
-                    <!-- /suffix -->
-
-
+                    <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
                 </div>
-                <!-- /city and state -->
 
-
-             <div class="row cr-question ">
-                <div class="span3 cr-label cr-question-with-checkbox">
+                <!-- suffix -->
+                <div class="span2 cr-label cr-question-right">
+                    <label for="cr-suffix2">
+                        State
+                        <small class="inline"></small>
+                    </label>
+                    <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
+                </div>
+                <!-- /suffix -->
+            </div>
+            <!-- /city and state -->
+            <div class="row cr-question">
+                <div class="span3 cr-label cr-question-left">
                     <label for="cr-first-name2_4851476384792477">
                         Website
                     </label>
                     <input type="text" name="cr-first-name2" id="cr-first-name2_4851476384792477" placeholder="">
                 </div>
+                <div class="span2 cr-label cr-question-right">
+                   <label for="cr-company-phone-2">
+                       Phone number
+                   </label>
+                   <input type="text" name="cr-company-phone-2" id="cr-company-phone-2">
+               </div>
+           </div>
 
+           <div class="row cr-question-last">
+            <div class="span3 cr-label cr-question">
+                <label for="cr-first-name2_4851476384792477">
+                   Other identifying characteristics
+               </label>
+               <textarea name="cr-other-identifying" id="cr-first-name2_4851476384792477" rows="4" columns="30" maxlength="4000" placeholder=""></textarea>
+               <p>Include any details that can help us identify the company, such as the names of company representatives, locations of store branches, and descriptions of branding and advertising.</p>
+           </div>
+       </div>
 
-             <div class="row cr-question-last">
-                <div class="span3 cr-label cr-question">
-                    <label for="cr-first-name2_4851476384792477">
-                     Other identifying characteristics
-                    </label>
-                    <textarea name="cr-other-identifying" id="cr-first-name2_4851476384792477" rows="4" columns="30" maxlength="4000" placeholder=""></textarea>
-                    <p>Include any details that can help us identify the company, such as the names of company representatives, locations of store branches, and descriptions of branding and advertising.</p>
-                </div>
+   </div>
 
-
-            </div>
-
-            </div>
-
-    </fieldset><!-- not-boarded -->
+</fieldset><!-- not-boarded -->
 
 <!-- THIS IS WHERE THE OPTIONS GO! -->
 
-  </div> <!-- company-type -->
+</div> <!-- company-type -->
 
-          </div>
-
-
+</div>
 <!--
 ///////////
 End company-2
 ///////////
 -->
-
-
-
-
-
-
 
 
 
@@ -454,8 +402,6 @@ END FIRST FIELDSETS
 ///////////
 ///////////
 -->
-
-
 <!--
 //////////
 ADDITIONAL COMPANY
@@ -464,130 +410,110 @@ ADDITIONAL COMPANY
 -->
 
 <div id="additional-company-div" class="cr-primary-container">
-        <h3 id="additional-company">Additional company</h3>
+    <h3 id="additional-company">Additional company</h3>
     <fieldset class="cr-fieldset">
         <!-- question -->
-<div class="row cr-question">
-    <fieldset class="cr-fieldset">
-        <div class="span3 cr-label">
-            <label>
-                Does this complaint involve an additional company? <small class="inline">(Optional)</small>
-                <div class='is-required'>Optional</div>
-            </label>
+        <div class="row cr-question">
+            <fieldset class="cr-fieldset">
+                <div class="span3 cr-label">
+                    <label>
+                        Does this complaint involve an additional company? <small class="inline">(Optional)</small>
+                        <div class='is-required'>Optional</div>
+                    </label>
+
+                </div>
+
+                <div class="span9 cr-answer cr-radios cr-behalf prodselect">
+                    <label class="radio block">
+                        <input type="radio" class='add-company-yes' name="add-company" value="yes">
+                        Yes
+                    </label>
+
+                    <label class="radio block last">
+                        <input type="radio" class='add-company-no' name="add-company" value="no">
+                        No
+                    </label>
+                </div>
+            </fieldset>
 
         </div>
-
-        <div class="span9 cr-answer cr-radios cr-behalf prodselect">
-            <label class="radio block">
-                <input type="radio" class='add-company-yes' name="add-company" value="yes">
-                Yes
-            </label>
-
-            <label class="radio block last">
-                <input type="radio" class='add-company-no' name="add-company" value="no">
-                No
-            </label>
-        </div>
-    </fieldset>
-
-</div>
-<!-- /question -->
+        <!-- /question -->
 
 
+        <fieldset class="cr-fieldset additional-company">
+            <!-- question -->
+            <div class="row cr-question">
 
-
-<fieldset class="cr-fieldset additional-company">
-        <!-- question -->
-         <div class="row cr-question">
-
-
-
-               <div class="span3 cr-label cr-question cr-question-last">
+             <div class="span3 cr-label cr-question cr-question-last">
                 <label id="additional-company-type" for="additional-consumer-identity">
                     What type of product or service does this company provide?
                     <div class='is-required'>Answer Required</div>
                 </label>
 
-                    <select name="additional-consumer-identity" id="additional-consumer-identity" class="input-medium">
-                        <option>Select one...</option>
-                  <option class="ans-con1-coborrower" value="Co-borrower">Credit reporting</option>
-                  <option class="ans-con1-coborrower" value="Co-borrower">Debt collection</option>
-                        <option class="ans-con1-primary-account" value="Primary account holder">Mortgage</option>
-                        <option class="ans-con1-additional-card-holder" value="Additional card holder">Student loan</option>
-                        <option class="ans-con1-cosigner" value="Co-Signer">Vehicle loan or lease</option>
-                  <option class="ans-con1-coborrower" value="Co-borrower">Credit or prepaid card</option>
-                  <option class="ans-con1-coborrower" value="Co-borrower">Checking or savings account</option>
-                        <option class="ans-con1-coborrower" value="Co-borrower">Money transfer or money service</option>
-                        <option class="ans-con1-coborrower" value="Co-borrower">Payday, online, store, or other loan</option>
-                    </select>
+                <select name="additional-consumer-identity" id="additional-consumer-identity" class="input-medium">
+                    <option>Select one...</option>
+                    <option class="ans-con1-coborrower" value="Co-borrower">Credit reporting</option>
+                    <option class="ans-con1-coborrower" value="Co-borrower">Debt collection</option>
+                    <option class="ans-con1-primary-account" value="Primary account holder">Mortgage</option>
+                    <option class="ans-con1-additional-card-holder" value="Additional card holder">Student loan</option>
+                    <option class="ans-con1-cosigner" value="Co-Signer">Vehicle loan or lease</option>
+                    <option class="ans-con1-coborrower" value="Co-borrower">Credit or prepaid card</option>
+                    <option class="ans-con1-coborrower" value="Co-borrower">Checking or savings account</option>
+                    <option class="ans-con1-coborrower" value="Co-borrower">Money transfer or money service</option>
+                    <option class="ans-con1-coborrower" value="Co-borrower">Payday, online, store, or other loan</option>
+                </select>
 
-                    <div id="ans-rel-other-who" style="display:none;">
-                        <input type="text" class="input-medium" name="cr-con1-other-who" id="cr-con1-other-who" placeholder="">
-                    </div>
+                <div id="ans-rel-other-who" style="display:none;">
+                    <input type="text" class="input-medium" name="cr-con1-other-who" id="cr-con1-other-who" placeholder="">
+                </div>
 
-               </div>
-
-
-        </div>
-</fieldset>
-
-
- <fieldset class="cr-fieldset additional-company company-name-fieldset-3">
-        <!-- question -->
-         <div class="row cr-question">
-
-
-
-        <div class="cr-question borrower-email cr-question-last">
-                    <div class="span3 cr-label cr-question-left cr-question-with-checkbox">
-                        <label class="autocomplete-company-name" for="company-2">
-                            Company name
-                            <div class='is-required'>Answer Required</div>
-                        </label>
-
-                        <input type="company3-name" name="company3-name" id="company3-name" placeholder="" class="input-large left company-name-input">
-
-                        <p id="forward-company3" class="forward-company-details">We will forward your complaint to this company and ask for a response.</p>
-                    </div>
-                    <div class="span2 cr-label cr-question-right right-helper question-checkbox company-2-checkbox additional-company-checkbox">
-                                <label class="radio block">
-                                    <input type="checkbox" name="company3-forward" value="company-unknown" class="cr-company-unknown checkbox" id="company3-forward">
-                                    This company should also receive and respond to this complaint.
-                                </label>
-                    </div>
             </div>
-
-
-          </div>
+        </div>
     </fieldset>
+    <fieldset class="cr-fieldset additional-company company-name-fieldset-3">
+        <!-- question -->
+        <div class="row cr-question">
 
+            <div class="cr-question borrower-email cr-question-last">
+                <div class="span3 cr-label cr-question-left cr-question-with-checkbox">
+                    <label class="autocomplete-company-name" for="company-2">
+                        Company name
+                        <div class='is-required'>Answer Required</div>
+                    </label>
 
+                    <input type="company3-name" name="company3-name" id="company3-name" placeholder="" class="input-large left company-name-input">
+
+                    <p id="forward-company3" class="forward-company-details">We will forward your complaint to this company and ask for a response.</p>
+                </div>
+                <div class="span2 cr-label cr-question-right right-helper question-checkbox company-2-checkbox additional-company-checkbox">
+                    <label class="radio block">
+                        <input type="checkbox" name="company3-forward" value="company-unknown" class="cr-company-unknown checkbox" id="company3-forward">
+                        This company should also receive and respond to this complaint.
+                    </label>
+                </div>
+            </div>
+        </div>
+    </fieldset>
 
     <fieldset id="company3-not-boarded" class="cr-fieldset company-not-boarded-info">
 
-            <div class="row cr-question">
+        <div class="row cr-question">
 
-                    <h3>This company is not in our complaint system</h3>
+            <h3>This company is not in our complaint system</h3>
 
-                    <p>This company is not currently in our system for receiving complaints. Please provide as much information as possible so that we can contact the company and send them your complaint.</p><p>If we find that another government agency would be better able to assist, we will forward your complaint and let you know.</p>
+            <p>This company is not currently in our system for receiving complaints. Please provide as much information as possible so that we can contact the company and send them your complaint.</p><p>If we find that another government agency would be better able to assist, we will forward your complaint and let you know.</p>
 
-
-
-             <div class="row cr-question ">
+            <div class="row cr-question ">
                 <div class="span3 cr-label cr-question-with-checkbox">
                     <label for="cr-first-name2_4851476384792477">
                         Other names
                     </label>
                     <input type="text" name="cr-first-name2" id="cr-first-name2_4851476384792477" placeholder="">
                 </div>
-
-
             </div>
 
 
-
-
-                    <div class="row cr-question ">
+            <div class="row cr-question ">
                 <div class="span3 cr-label cr-question-left ">
                     <label for="cr-first-name2_4851476384792477">
                         Company address
@@ -602,62 +528,59 @@ ADDITIONAL COMPANY
                     <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477" placeholder="">
                 </div>
             </div>
-
-
-                <div class="row cr-question cr-question">
+            <div class="row cr-question cr-question">
                 <div class="span3 cr-label cr-question-left">
-                        <label for="cr-last-name2_4851476384792477">
-                            Address line 2 <small class="inline">(Optional)</small>
-                            <div class='is-required'>Answer Required</div>
-                        </label>
+                    <label for="cr-last-name2_4851476384792477">
+                        Address line 2 <small class="inline">(Optional)</small>
+                        <div class='is-required'>Answer Required</div>
+                    </label>
 
-                        <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
-                    </div>
+                    <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
+                </div>
 
-                    <!-- suffix -->
-                    <div class="span2 cr-label cr-question-right">
-                        <label for="cr-suffix2">
-                            State
-                            <small class="inline"></small>
-                        </label>
+                <!-- suffix -->
+                <div class="span2 cr-label cr-question-right">
+                    <label for="cr-suffix2">
+                        State
+                        <small class="inline"></small>
+                    </label>
 
-
-                        <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
-
-
-                    </div>
-                    <!-- /suffix -->
-
+                    <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
 
                 </div>
-                <!-- /city and state -->
+                <!-- /suffix -->
 
+            </div>
+            <!-- /city and state -->
 
-             <div class="row cr-question ">
-                <div class="span3 cr-label cr-question-with-checkbox">
+            <div class="row cr-question">
+                <div class="span3 cr-label cr-question-left">
                     <label for="cr-first-name2_4851476384792477">
                         Website
                     </label>
                     <input type="text" name="cr-first-name2" id="cr-first-name2_4851476384792477" placeholder="">
                 </div>
+                <div class="span2 cr-label cr-question-right">
+                    <label for="cr-company-phone-3">
+                       Phone number
+                   </label>
+                   <input type="text" name="cr-company-phone-3" id="cr-company-phone-3">
+               </div>
+           </div>
 
+           <div class="row cr-question-last">
+            <div class="span3 cr-label cr-question">
+                <label for="cr-first-name2_4851476384792477">
+                   Other identifying characteristics
+               </label>
+               <textarea name="cr-other-identifying" id="cr-first-name2_4851476384792477" rows="4" columns="30" maxlength="4000" placeholder=""></textarea>
+               <p>Include any details that can help us identify the company, such as the names of company representatives, locations of store branches, and descriptions of branding and advertising.</p>
+           </div>
+       </div>
 
-             <div class="row cr-question-last">
-                <div class="span3 cr-label cr-question">
-                    <label for="cr-first-name2_4851476384792477">
-                     Other identifying characteristics
-                    </label>
-                    <textarea name="cr-other-identifying" id="cr-first-name2_4851476384792477" rows="4" columns="30" maxlength="4000" placeholder=""></textarea>
-                    <p>Include any details that can help us identify the company, such as the names of company representatives, locations of store branches, and descriptions of branding and advertising.</p>
-                </div>
+   </div>
 
-
-            </div>
-
-            </div>
-
-    </fieldset><!-- not-boarded -->
-
+</fieldset><!-- not-boarded -->
 
 <!--
 
@@ -667,12 +590,6 @@ END OF Additional Company
 
 -->
 
-
-
-
-
-
-
 <!--
 
 ////////////////////////////////////////////
@@ -681,49 +598,40 @@ END OF Additional Company
 
 -->
 
-
-
-
 <fieldset id="bankwell-company-options" class="cr-fieldset company_verification_fieldset">
 
-            <div class="row cr-question">
+    <div class="row cr-question">
 
-                    <h4>Verify company name</h4>
+        <h4>Verify company name</h4>
 
-                    <p>This company name is often mistaken for other companies!<br/>Please select the correct company from the list below.</p>
+        <p>This company name is often mistaken for other companies!<br/>Please select the correct company from the list below.</p>
 
-                    <div class="company-name-option">
-                        <p><strong>Bankwell Finance</strong>
-                        <br/>bankwellloans.com</p>
-                        <label for=""><button class="btn-secondary" type="button">Select this company</button></label>
-                    </div>
+        <div class="company-name-option">
+            <p><strong>Bankwell Finance</strong>
+                <br/>bankwellloans.com</p>
+                <label for=""><button class="btn-secondary" type="button">Select this company</button></label>
+            </div>
 
-                    <div class="company-name-option">
-                        <p><strong>Bank of Wellington Finance</strong>
-                        <br/>wellingtonfinance.com</p>
-                        <label for=""><button class="btn-secondary" type="button">Select this company</button></label>
-                    </div>
+            <div class="company-name-option">
+                <p><strong>Bank of Wellington Finance</strong>
+                    <br/>wellingtonfinance.com</p>
+                    <label for=""><button class="btn-secondary" type="button">Select this company</button></label>
+                </div>
 
-                    <div class="company-name-option">
-                        <p><strong>Well Bank Loans</strong>
+                <div class="company-name-option">
+                    <p><strong>Well Bank Loans</strong>
                         <br/>wellbankloans.com</p>
                         <label for=""><button class="btn-secondary" type="button">Select this company</button></label>
                     </div>
 
-            </div>
+                </div>
 
-    </fieldset>
-
-
+            </fieldset>
 
 
+            <fieldset id="kwik-company-options" class="cr-fieldset company_verification_fieldset">
 
-
-
-
-<fieldset id="kwik-company-options" class="cr-fieldset company_verification_fieldset">
-
-            <div class="row cr-question">
+                <div class="row cr-question">
 
                     <h4>Verify company name</h4>
 
@@ -731,589 +639,505 @@ END OF Additional Company
 
                     <div class="company-name-option">
                         <p><strong>Kwik Cash</strong>
-                        <br/>kwikcash.com</p>
-                        <label for=""><button class="btn-secondary" type="button">Select this company</button></label>
-                    </div>
+                            <br/>kwikcash.com</p>
+                            <label for=""><button class="btn-secondary" type="button">Select this company</button></label>
+                        </div>
 
-                    <div class="company-name-option">
-                        <p><strong>Quick Cash</strong>
-                        <br/>quick-cash.com</p>
-                        <label for=""><button class="btn-secondary" type="button">Select this company</button></label>
-                    </div>
+                        <div class="company-name-option">
+                            <p><strong>Quick Cash</strong>
+                                <br/>quick-cash.com</p>
+                                <label for=""><button class="btn-secondary" type="button">Select this company</button></label>
+                            </div>
 
-                    <div class="company-name-option">
-                        <p><strong>Kwik Kash</strong>
-                        <br/>kwikkashloans.com</p>
-                        <label for=""><button class="btn-secondary" type="button">Select this company</button></label>
-                    </div>
+                            <div class="company-name-option">
+                                <p><strong>Kwik Kash</strong>
+                                    <br/>kwikkashloans.com</p>
+                                    <label for=""><button class="btn-secondary" type="button">Select this company</button></label>
+                                </div>
 
-            </div>
+                            </div>
 
-    </fieldset>
-
-
+                        </fieldset>
 
 
 <!--
 /////
 MORTGAGE OPTIONS.
 /////
- -->
+-->
 
 <fieldset id="identify-mortgage-company" class="cr-fieldset identify-product-options">
 
-            <div class="row cr-question">
-                    <div class="span3 cr-label">
-                        <label>
-                            How should this company identify you?
-                            <div class='is-required'>Required</div>
-                        </label>
+    <div class="row cr-question">
+        <div class="span3 cr-label">
+            <label>
+                How should this company identify you?
+                <div class='is-required'>Required</div>
+            </label>
 
-                    </div>
+        </div>
 
-                    <div class="span9 cr-answer cr-radios cr-behalf prodselect">
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type loan-number' name="identify-account" value="loan-number">
-                            Loan number
-                        </label>
+        <div class="span9 cr-answer cr-radios cr-behalf prodselect">
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type loan-number' name="identify-account" value="loan-number">
+                Loan number
+            </label>
 
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
-                            Account number
-                        </label>
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
+                Account number
+            </label>
 
-                        <label class="radio block last">
-                            <input type="radio" class='identify-account identification-type residence-address' name="identify-account" value="residence-address">
-                            Residence address
-                        </label>
+            <label class="radio block last">
+                <input type="radio" class='identify-account identification-type residence-address' name="identify-account" value="residence-address">
+                Residence address
+            </label>
 
-                        <label class="radio block last">
-                            <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
-                            Billing address
-                        </label>
+            <label class="radio block last">
+                <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
+                Billing address
+            </label>
 
-                    </div>
-            </div>
+        </div>
+    </div>
 
-    </fieldset>
-
-
+</fieldset>
 
 <!--
 /////
 STUDENT LOAN OPTIONS.
 /////
- -->
+-->
 
-    <fieldset id="identify-student-loan-company" class="cr-fieldset identify-product-options">
+<fieldset id="identify-student-loan-company" class="cr-fieldset identify-product-options">
 
-            <div class="row cr-question">
-                    <div class="span3 cr-label">
-                        <label>
-                            How should this company identify you?
-                            <div class='is-required'>Required</div>
-                        </label>
+    <div class="row cr-question">
+        <div class="span3 cr-label">
+            <label>
+                How should this company identify you?
+                <div class='is-required'>Required</div>
+            </label>
 
-                    </div>
+        </div>
 
-                    <div class="span9 cr-answer cr-radios cr-behalf prodselect">
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type loan-number' name="identify-account" value="loan-number">
-                            Loan number
-                        </label>
+        <div class="span9 cr-answer cr-radios cr-behalf prodselect">
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type loan-number' name="identify-account" value="loan-number">
+                Loan number
+            </label>
 
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
-                            Account number
-                        </label>
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
+                Account number
+            </label>
 
-                        <label class="radio block last">
-                            <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
-                            Billing address
-                        </label>
+            <label class="radio block last">
+                <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
+                Billing address
+            </label>
 
-                        <label class="radio block last">
-                            <input type="radio" class='identify-account identification-type social-security-number' name="identify-account" value="social-security-number">
-                            Social security number
-                        </label>
+            <label class="radio block last">
+                <input type="radio" class='identify-account identification-type social-security-number' name="identify-account" value="social-security-number">
+                Social security number
+            </label>
 
-                    </div>
-            </div>
+        </div>
+    </div>
 
-    </fieldset>
-
-
+</fieldset>
 
 <!--
 /////
 PAYDAY & INSTALLMENT LOAN OPTIONS.
 /////
- -->
+-->
 
-    <fieldset id="identify-payday-other-loan-company" class="cr-fieldset identify-product-options">
+<fieldset id="identify-payday-other-loan-company" class="cr-fieldset identify-product-options">
 
-            <div class="row cr-question">
-                    <div class="span3 cr-label">
-                        <label>
-                            How should this company identify you?
-                            <div class='is-required'>Required</div>
-                        </label>
+    <div class="row cr-question">
+        <div class="span3 cr-label">
+            <label>
+                How should this company identify you?
+                <div class='is-required'>Required</div>
+            </label>
 
-                    </div>
+        </div>
 
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type loan-number' name="identify-account" value="loan-number">
-                            Loan number
-                        </label>
+        <label class="radio block">
+            <input type="radio" class='identify-account identification-type loan-number' name="identify-account" value="loan-number">
+            Loan number
+        </label>
 
-                        <label class="radio block last">
-                            <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
-                            Billing address
-                        </label>
-                    </div>
-            </div>
+        <label class="radio block last">
+            <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
+            Billing address
+        </label>
+    </div>
+</div>
 
-    </fieldset>
-
-
+</fieldset>
 
 <!--
 /////
 VEHICLE LOAN OR LEASE OPTIONS.
 /////
- -->
+-->
 
-    <fieldset id="identify-vehicle-loan-company" class="cr-fieldset identify-product-options">
+<fieldset id="identify-vehicle-loan-company" class="cr-fieldset identify-product-options">
 
-            <div class="row cr-question">
-                    <div class="span3 cr-label">
-                        <label>
-                            How should this company identify you?
-                            <div class='is-required'>Required</div>
-                        </label>
+    <div class="row cr-question">
+        <div class="span3 cr-label">
+            <label>
+                How should this company identify you?
+                <div class='is-required'>Required</div>
+            </label>
 
-                    </div>
+        </div>
 
-                    <div class="span9 cr-answer cr-radios prodselect cr-behalf">
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type loan-number' name="identify-account" value="loan-number">
-                            Loan number
-                        </label>
+        <div class="span9 cr-answer cr-radios prodselect cr-behalf">
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type loan-number' name="identify-account" value="loan-number">
+                Loan number
+            </label>
 
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
-                            Account number
-                        </label>
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
+                Account number
+            </label>
 
-                        <label class="radio block last">
-                            <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
-                            Billing address
-                        </label>
+            <label class="radio block last">
+                <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
+                Billing address
+            </label>
+        </div>
+    </div>
 
-
-                    </div>
-            </div>
-
-    </fieldset>
-
-
+</fieldset>
 
 <!--
 /////
 CHECKING OR SAVINGS OPTIONS.
 /////
- -->
+-->
 
-    <fieldset id="identify-checking-savings-company" class="cr-fieldset identify-product-options">
+<fieldset id="identify-checking-savings-company" class="cr-fieldset identify-product-options">
 
-            <div class="row cr-question">
-                    <div class="span3 cr-label">
-                        <label>
-                            How should this company identify you?
-                            <div class='is-required'>Required</div>
-                        </label>
+    <div class="row cr-question">
+        <div class="span3 cr-label">
+            <label>
+                How should this company identify you?
+                <div class='is-required'>Required</div>
+            </label>
 
-                    </div>
-                    <div class="span9 cr-answer cr-radios prodselect cr-behalf">
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
-                            Account number
-                        </label>
+        </div>
+        <div class="span9 cr-answer cr-radios prodselect cr-behalf">
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
+                Account number
+            </label>
 
-                        <label class="radio block last">
-                            <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
-                            Billing address
-                        </label>
+            <label class="radio block last">
+                <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
+                Billing address
+            </label>
+        </div>
+    </div>
 
-
-                    </div>
-            </div>
-
-    </fieldset>
-
+</fieldset>
 
 <!--
 /////
 MONEY TRANSFER OPTIONS.
 /////
- -->
+-->
 
-    <fieldset id="identify-money-transfer-company" class="cr-fieldset identify-product-options">
+<fieldset id="identify-money-transfer-company" class="cr-fieldset identify-product-options">
 
-            <div class="row cr-question">
-                    <div class="span3 cr-label">
-                        <label>
-                            How should this company identify you?
-                            <div class='is-required'>Required</div>
-                        </label>
+    <div class="row cr-question">
+        <div class="span3 cr-label">
+            <label>
+                How should this company identify you?
+                <div class='is-required'>Required</div>
+            </label>
 
-                    </div>
+        </div>
 
-                    <div class="span9 cr-answer cr-radios prodselect cr-behalf">
+        <div class="span9 cr-answer cr-radios prodselect cr-behalf">
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
+                Account number
+            </label>
 
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type transaction-number' name="identify-account" value="transaction-number">
+                Transaction number
+            </label>
 
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
-                            Account number
-                        </label>
+        </div>
+    </div>
 
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type transaction-number' name="identify-account" value="transaction-number">
-                            Transaction number
-                        </label>
-
-                    </div>
-            </div>
-
-    </fieldset>
-
-
-
-
-
-
+</fieldset>
 
 <!--
 /////
 CREDIT REPORTING OPTIONS.
 /////
- -->
+-->
 
-    <fieldset id="identify-credit-reporting-company" class="cr-fieldset identify-product-options">
+<fieldset id="identify-credit-reporting-company" class="cr-fieldset identify-product-options">
 
-            <div class="row cr-question">
-                    <div class="span3 cr-label">
-                        <label>
-                            How should this company identify you?
-                            <div class='is-required'>Required</div>
-                        </label>
+    <div class="row cr-question">
+        <div class="span3 cr-label">
+            <label>
+                How should this company identify you?
+                <div class='is-required'>Required</div>
+            </label>
 
-                    </div>
+        </div>
 
-                    <div class="span9 cr-answer cr-radios prodselect cr-behalf">
+        <div class="span9 cr-answer cr-radios prodselect cr-behalf">
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
+                Account number
+            </label>
 
-
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
-                            Account number
-                        </label>
-
-                        <label class="radio block last">
-                            <input type="radio" class='identify-account identification-type address-dob' name="identify-account" value="address-dob">
-                            Residence address + Date of birth
-                        </label>
-
-
-                        <label class="radio block last">
-                            <input type="radio" class='identify-account identification-type social-security-number' name="identify-account" value="social-security-number">
-                            Social security number
-                        </label>
+            <label class="radio block last">
+                <input type="radio" class='identify-account identification-type address-dob' name="identify-account" value="address-dob">
+                Residence address + Date of birth
+            </label>
+            <label class="radio block last">
+                <input type="radio" class='identify-account identification-type social-security-number' name="identify-account" value="social-security-number">
+                Social security number
+            </label>
 
 
+        </div>
+    </div>
 
-
-                    </div>
-            </div>
-
-    </fieldset>
-
-
-
-
-
+</fieldset>
 
 <!--
 /////
 DEBT COLLECTION OPTIONS.
 /////
- -->
+-->
 
-    <fieldset id="identify-debt-collection-company" class="cr-fieldset identify-product-options">
+<fieldset id="identify-debt-collection-company" class="cr-fieldset identify-product-options">
 
-            <div class="row cr-question">
-                    <div class="span3 cr-label">
-                        <label>
-                            How should this company identify you?
-                            <div class='is-required'>Required</div>
-                        </label>
+    <div class="row cr-question">
+        <div class="span3 cr-label">
+            <label>
+                How should this company identify you?
+                <div class='is-required'>Required</div>
+            </label>
 
-                    </div>
+        </div>
 
-                    <div class="span9 cr-answer cr-radios prodselect cr-behalf">
+        <div class="span9 cr-answer cr-radios prodselect cr-behalf">
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
+                Account number
+            </label>
 
+            <label class="radio block last">
+                <input type="radio" class='identify-account identification-type social-security-last-four' name="identify-account" value="social-security-last-four">
+                Last four digits of Social Security Number
+            </label>
 
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
-                            Account number
-                        </label>
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type loan-number' name="identify-account" value="loan-number">
+                Loan number
+            </label>
 
-                        <label class="radio block last">
-                            <input type="radio" class='identify-account identification-type social-security-last-four' name="identify-account" value="social-security-last-four">
-                            Last four digits of Social Security Number
-                        </label>
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type loan-number' name="identify-account" value="debt-collection-phone-number">
+                Phone number
+            </label>
+        </div>
+    </div>
 
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type loan-number' name="identify-account" value="loan-number">
-                            Loan number
-                        </label>
-
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type loan-number' name="identify-account" value="debt-collection-phone-number">
-                            Phone number
-                        </label>
-
-
-                    </div>
-            </div>
-
-    </fieldset>
-
-
-
-
+</fieldset>
 
 
 <!--
 /////
 CREDIT REPAIR, DEBT SETTLEMENT OPTIONS.
 /////
- -->
+-->
 
-    <fieldset id="identify-credit-debt-repair-company" class="cr-fieldset identify-product-options">
+<fieldset id="identify-credit-debt-repair-company" class="cr-fieldset identify-product-options">
 
-            <div class="row cr-question">
-                    <div class="span3 cr-label">
-                        <label>
-                            How should this company identify you?
-                            <div class='is-required'>Required</div>
-                        </label>
+    <div class="row cr-question">
+        <div class="span3 cr-label">
+            <label>
+                How should this company identify you?
+                <div class='is-required'>Required</div>
+            </label>
 
-                    </div>
+        </div>
 
-                    <div class="span9 cr-answer cr-radios prodselect cr-behalf">
+        <div class="span9 cr-answer cr-radios prodselect cr-behalf">
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
+                Account number
+            </label>
 
+            <label class="radio block last">
+                <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
+                Billing address
+            </label>
 
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
-                            Account number
-                        </label>
+        </div>
+    </div>
 
-                        <label class="radio block last">
-                            <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
-                            Billing address
-                        </label>
-
-                    </div>
-            </div>
-
-    </fieldset>
-
-
-
-
-
-
+</fieldset>
 
 <!--
 /////
 STOREFRONT SERVICES OPTIONS.
 /////
- -->
+-->
 
-    <fieldset id="identify-storefront-services-company" class="cr-fieldset identify-product-options">
+<fieldset id="identify-storefront-services-company" class="cr-fieldset identify-product-options">
 
-            <div class="row cr-question">
-                    <div class="span3 cr-label">
-                        <label>
-                            How should this company identify you?
-                            <div class='is-required'>Required</div>
-                        </label>
+    <div class="row cr-question">
+        <div class="span3 cr-label">
+            <label>
+                How should this company identify you?
+                <div class='is-required'>Required</div>
+            </label>
 
-                    </div>
+        </div>
 
-                    <div class="span9 cr-answer cr-radios prodselect cr-behalf">
+        <div class="span9 cr-answer cr-radios prodselect cr-behalf">
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
+                Account number
+            </label>
 
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type transaction-number' name="identify-account" value="transaction-number">
+                Transaction number
+            </label>
 
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
-                            Account number
-                        </label>
+            <label class="radio block last">
+                <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
+                Billing address
+            </label>
 
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type transaction-number' name="identify-account" value="transaction-number">
-                            Transaction number
-                        </label>
+        </div>
+    </div>
 
-                        <label class="radio block last">
-                            <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
-                            Billing address
-                        </label>
-
-                    </div>
-            </div>
-
-    </fieldset>
-
-
-
-
-
-
-
-
+</fieldset>
 
 <!--
 /////
 MOST PREPAIDS OPTIONS.
 /////
- -->
+-->
 
-    <fieldset id="identify-most-prepaids-company" class="cr-fieldset identify-product-options">
+<fieldset id="identify-most-prepaids-company" class="cr-fieldset identify-product-options">
 
-            <div class="row cr-question">
-                    <div class="span3 cr-label">
-                        <label>
-                            How should this company identify you?
-                            <div class='is-required'>Required</div>
-                        </label>
+    <div class="row cr-question">
+        <div class="span3 cr-label">
+            <label>
+                How should this company identify you?
+                <div class='is-required'>Required</div>
+            </label>
 
-                    </div>
+        </div>
 
-                    <div class="span9 cr-answer cr-radios prodselect cr-behalf">
+        <div class="span9 cr-answer cr-radios prodselect cr-behalf">
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
+                Account number
+            </label>
 
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type card-number' name="identify-account" value="card-number">
+                Card number
+            </label>
 
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
-                            Account number
-                        </label>
+            <label class="radio block last">
+                <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
+                Billing address
+            </label>
 
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type card-number' name="identify-account" value="card-number">
-                            Card number
-                        </label>
+        </div>
+    </div>
 
-                        <label class="radio block last">
-                            <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
-                            Billing address
-                        </label>
-
-                    </div>
-            </div>
-
-    </fieldset>
-
-
-
-
-
-
-
+</fieldset>
 
 <!--
 /////
 PAYROLL AND GOVT PREPAIDS OPTIONS.
 /////
- -->
+-->
 
-    <fieldset id="identify-payroll-govt-prepaid-company" class="cr-fieldset identify-product-options">
+<fieldset id="identify-payroll-govt-prepaid-company" class="cr-fieldset identify-product-options">
 
-            <div class="row cr-question">
-                    <div class="span3 cr-label">
-                        <label>
-                            How should this company identify you?
-                            <div class='is-required'>Required</div>
-                        </label>
+    <div class="row cr-question">
+        <div class="span3 cr-label">
+            <label>
+                How should this company identify you?
+                <div class='is-required'>Required</div>
+            </label>
 
-                    </div>
+        </div>
 
-                    <div class="span9 cr-answer cr-radios prodselect cr-behalf">
+        <div class="span9 cr-answer cr-radios prodselect cr-behalf">
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
+                Account number
+            </label>
 
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type card-number' name="identify-account" value="card-number">
+                Card number
+            </label>
 
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
-                            Account number
-                        </label>
+            <label class="radio block last">
+                <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
+                Billing address
+            </label>
 
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type card-number' name="identify-account" value="card-number">
-                            Card number
-                        </label>
+        </div>
+    </div>
 
-                        <label class="radio block last">
-                            <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
-                            Billing address
-                        </label>
-
-                    </div>
-            </div>
-
-    </fieldset>
-
-
-
-
-
-
+</fieldset>
 
 <!--
 /////
 MOBILE WALLET OPTIONS.
 /////
- -->
+-->
 
-    <fieldset id="identify-mobile-wallet-company" class="cr-fieldset identify-product-options">
+<fieldset id="identify-mobile-wallet-company" class="cr-fieldset identify-product-options">
 
-            <div class="row cr-question">
-                    <div class="span3 cr-label">
-                        <label>
-                            How should this company identify you?
-                            <div class='is-required'>Required</div>
-                        </label>
+    <div class="row cr-question">
+        <div class="span3 cr-label">
+            <label>
+                How should this company identify you?
+                <div class='is-required'>Required</div>
+            </label>
 
-                    </div>
+        </div>
 
-                    <div class="span9 cr-answer cr-radios prodselect cr-behalf">
+        <div class="span9 cr-answer cr-radios prodselect cr-behalf">
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
+                Account number
+            </label>
 
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type email-address' name="identify-account" value="email-address">
+                Email address on account
+            </label>
 
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
-                            Account number
-                        </label>
+        </div>
+    </div>
 
-                        <label class="radio block">
-                            <input type="radio" class='identify-account identification-type email-address' name="identify-account" value="email-address">
-                            Email address on account
-                        </label>
-
-                    </div>
-            </div>
-
-    </fieldset>
-
-
-
-
-
+</fieldset>
 
 <!--
 
@@ -1322,10 +1146,6 @@ MOBILE WALLET OPTIONS.
 ////////////////////////////////////////////////////
 
 -->
-
-
-
-
 
 <!--
 
@@ -1339,313 +1159,255 @@ MOBILE WALLET OPTIONS.
 
   <fieldset class="cr-fieldset identify-options billing-address in-repository">
 
-            <div class="row cr-question ">
-                <div class="span3 cr-label cr-question-left ">
-                    <label for="cr-first-name2_4851476384792477">
-                        Billing address line 1
-                    </label>
-                    <input type="text" name="cr-first-name2" id="cr-first-name2_4851476384792477" placeholder="">
-                </div>
+    <div class="row cr-question ">
+        <div class="span3 cr-label cr-question-left ">
+            <label for="cr-first-name2_4851476384792477">
+                Billing address line 1
+            </label>
+            <input type="text" name="cr-first-name2" id="cr-first-name2_4851476384792477" placeholder="">
+        </div>
 
-                <div class="span2 cr-label cr-question-right">
-                    <label for="cr-middle-name2_4851476384792477">
-                        City
-                    </label>
-                    <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477" placeholder="">
-                </div>
-            </div>
+        <div class="span2 cr-label cr-question-right">
+            <label for="cr-middle-name2_4851476384792477">
+                City
+            </label>
+            <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477" placeholder="">
+        </div>
+    </div>
+    <div class="row cr-question cr-question-last">
+        <div class="span3 cr-label cr-question-left">
+            <label for="cr-last-name2_4851476384792477">
+                Address line 2 <small class="inline">(Optional)</small>
+                <div class='is-required'>Answer Required</div>
+            </label>
 
+            <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
+        </div>
 
-                <div class="row cr-question cr-question-last">
-                <div class="span3 cr-label cr-question-left">
-                        <label for="cr-last-name2_4851476384792477">
-                            Address line 2 <small class="inline">(Optional)</small>
-                            <div class='is-required'>Answer Required</div>
-                        </label>
-
-                        <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
-                    </div>
-
-                    <!-- suffix -->
-                    <div class="span2 cr-label cr-question-right">
-                        <label for="cr-suffix2">
-                            State
-                            <small class="inline"></small>
-                        </label>
-
-
-                        <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
-
-
-                    </div>
-                    <!-- /suffix -->
-
-
-                </div>
-                <!-- /city and state -->
-    </fieldset>
-
-
+        <!-- suffix -->
+        <div class="span2 cr-label cr-question-right">
+            <label for="cr-suffix2">
+                State
+                <small class="inline"></small>
+            </label>
+            <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
+        </div>
+        <!-- /suffix -->
+    </div>
+    <!-- /city and state -->
+</fieldset>
 <fieldset class="cr-fieldset identify-options residence-address in-repository">
 
-            <div class="row cr-question ">
-                <div class="span3 cr-label cr-question-left ">
-                    <label for="cr-first-name2_4851476384792477">
-                        Residence address line 1
-                    </label>
-                    <input type="text" name="cr-first-name2" id="cr-first-name2_4851476384792477" placeholder="">
-                </div>
+    <div class="row cr-question ">
+        <div class="span3 cr-label cr-question-left ">
+            <label for="cr-first-name2_4851476384792477">
+                Residence address line 1
+            </label>
+            <input type="text" name="cr-first-name2" id="cr-first-name2_4851476384792477" placeholder="">
+        </div>
 
-                <div class="span2 cr-label cr-question-right">
-                    <label for="cr-middle-name2_4851476384792477">
-                        City
-                    </label>
-                    <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477" placeholder="">
-                </div>
-            </div>
+        <div class="span2 cr-label cr-question-right">
+            <label for="cr-middle-name2_4851476384792477">
+                City
+            </label>
+            <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477" placeholder="">
+        </div>
+    </div>
+    <div class="row cr-question cr-question-last">
+        <div class="span3 cr-label cr-question-left">
+            <label for="cr-last-name2_4851476384792477">
+                Address line 2 <small class="inline">(Optional)</small>
+                <div class='is-required'>Answer Required</div>
+            </label>
 
+            <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
+        </div>
 
-                <div class="row cr-question cr-question-last">
-                <div class="span3 cr-label cr-question-left">
-                        <label for="cr-last-name2_4851476384792477">
-                            Address line 2 <small class="inline">(Optional)</small>
-                            <div class='is-required'>Answer Required</div>
-                        </label>
-
-                        <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
-                    </div>
-
-                    <!-- suffix -->
-                    <div class="span2 cr-label cr-question-right">
-                        <label for="cr-suffix2">
-                            State
-                            <small class="inline"></small>
-                        </label>
-
-
-                        <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
-
-
-                    </div>
-                    <!-- /suffix -->
-
-
-                </div>
-                <!-- /city and state -->
-    </fieldset>
-
-
+        <!-- suffix -->
+        <div class="span2 cr-label cr-question-right">
+            <label for="cr-suffix2">
+                State
+                <small class="inline"></small>
+            </label>
+            <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
+        </div>
+        <!-- /suffix -->
+    </div>
+    <!-- /city and state -->
+</fieldset>
 
 
 <fieldset class="cr-fieldset identify-options address-dob in-repository">
 
-            <div class="row cr-question ">
-                <div class="span3 cr-label cr-question-left ">
-                    <label for="cr-first-name2_4851476384792477">
-                        Residence address line 1
-                    </label>
-                    <input type="text" name="cr-first-name2" id="cr-first-name2_4851476384792477" placeholder="">
-                </div>
+    <div class="row cr-question ">
+        <div class="span3 cr-label cr-question-left ">
+            <label for="cr-first-name2_4851476384792477">
+                Residence address line 1
+            </label>
+            <input type="text" name="cr-first-name2" id="cr-first-name2_4851476384792477" placeholder="">
+        </div>
 
-                <div class="span2 cr-label cr-question-right">
-                    <label for="cr-middle-name2_4851476384792477">
-                        City
-                    </label>
-                    <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477" placeholder="">
-                </div>
-            </div>
+        <div class="span2 cr-label cr-question-right">
+            <label for="cr-middle-name2_4851476384792477">
+                City
+            </label>
+            <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477" placeholder="">
+        </div>
+    </div>
+    <div class="row cr-question">
+        <div class="span3 cr-label cr-question-left cr-question-last">
+            <label for="cr-last-name2_4851476384792477">
+                Address line 2 <small class="inline">(Optional)</small>
+                <div class='is-required'>Answer Required</div>
+            </label>
 
+            <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
+        </div>
 
-                <div class="row cr-question">
-                <div class="span3 cr-label cr-question-left cr-question-last">
-                        <label for="cr-last-name2_4851476384792477">
-                            Address line 2 <small class="inline">(Optional)</small>
-                            <div class='is-required'>Answer Required</div>
-                        </label>
-
-                        <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
-                    </div>
-
-                    <!-- suffix -->
-                    <div class="span2 cr-label cr-question-right">
-                        <label for="cr-suffix2">
-                            State
-                            <small class="inline"></small>
-                        </label>
-
-
-                        <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
-
-
-                    </div>
-                    <!-- /suffix -->
-
-
-                </div>
+        <!-- suffix -->
+        <div class="span2 cr-label cr-question-right">
+            <label for="cr-suffix2">
+                State
+                <small class="inline"></small>
+            </label>
+            <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
+        </div>
+        <!-- /suffix -->
+    </div>
 
 </fieldset>
 <fieldset class="cr-fieldset identify-options address-dob in-repository">
+    <div class="row cr-question cr-question-last">
+        <div class="span3 cr-label cr-question-left">
+            <label for="cr-last-name2_4851476384792477">
+                Date of birth <small class="inline"></small>
+                <div class='is-required'>Answer Required</div>
+            </label>
+
+            <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
+        </div>
+
+        <!-- suffix -->
+        <div class="span2 cr-label cr-question-right right-helper">
+            <p>Use format MM/DD/YYYY</p>
+        </div>
+        <!-- /suffix -->
+    </div>
+    <!-- /city and state -->
+</fieldset>
+
+<fieldset class="cr-fieldset identify-options card-number in-repository">
+
+    <div class="row cr-question cr-question-last account-number-row">
+        <div class="span3 cr-label cr-question-left">
+            <label for="cr-first-name2_4851476384792477">
+                Card number
+            </label>
+            <input type="text" name="company-account" id="company-account" class="accountinput" placeholder="">
+        </div>
+
+        <div class="span2 cr-label cr-question-right right-helper">
+            <p>This number is on the front of your card</p>
+        </div>
+    </div>
+</fieldset>
+
+<fieldset class="cr-fieldset identify-options account-number in-repository">
+
+    <div class="row cr-question cr-question-last account-number-row">
+        <div class="span3 cr-label cr-question-left">
+            <label for="cr-first-name2_4851476384792477">
+                Account number
+            </label>
+            <input type="text" name="company-account" id="company-account" class="accountinput" placeholder="">
+        </div>
+
+        <div class="span2 cr-label cr-question-right right-helper">
+            <p>This number is on your billing statements</p>
+        </div>
+    </div>
+</fieldset>
 
 
-                <div class="row cr-question cr-question-last">
-                <div class="span3 cr-label cr-question-left">
-                        <label for="cr-last-name2_4851476384792477">
-                            Date of birth <small class="inline"></small>
-                            <div class='is-required'>Answer Required</div>
-                        </label>
+<fieldset class="cr-fieldset identify-options loan-number in-repository">
 
-                        <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
-                    </div>
+    <div class="row cr-question cr-question-last account-number-row">
+        <div class="span3 cr-label cr-question-left">
+            <label for="cr-first-name2_4851476384792477">
+                Loan number
+            </label>
+            <input type="text" name="company-account" id="company-account" class="accountinput" placeholder="">
+        </div>
 
-                    <!-- suffix -->
-                <div class="span2 cr-label cr-question-right right-helper">
-                    <p>Use format MM/DD/YYYY</p>
-                </div>
-                    <!-- /suffix -->
+        <div class="span2 cr-label cr-question-right right-helper">
+            <p>This number is on your loan documents</p>
+        </div>
+    </div>
+</fieldset>
+<fieldset class="cr-fieldset identify-options transaction-number in-repository">
 
+    <div class="row cr-question cr-question-last account-number-row">
+        <div class="span3 cr-label cr-question-left">
+            <label for="cr-first-name2_4851476384792477">
+                Transaction number
+            </label>
+            <input type="text" name="company-account" id="company-account" class="accountinput" placeholder="">
+        </div>
 
-                </div>
-                <!-- /city and state -->
-    </fieldset>
+        <div class="span2 cr-label cr-question-right right-helper">
+            <p>This number is on your transaction receipt</p>
+        </div>
+    </div>
+</fieldset>
+<fieldset class="cr-fieldset identify-options social-security-number in-repository">
 
+    <div class="row cr-question cr-question-last account-number-row">
+        <div class="span3 cr-label cr-question-left">
+            <label for="cr-first-name2_4851476384792477">
+                Social security number
+            </label>
+            <input type="text" name="company-account" id="company-account" class="accountinput" placeholder="">
+        </div>
 
+        <div class="span2 cr-label cr-question-right right-helper">
+            <p>Use format<br/>XXX-XX-XXXX</p>
+        </div>
+    </div>
+</fieldset>
 
-     <fieldset class="cr-fieldset identify-options card-number in-repository">
+<fieldset class="cr-fieldset identify-options social-security-last-four in-repository">
 
-            <div class="row cr-question cr-question-last account-number-row">
-                <div class="span3 cr-label cr-question-left">
-                    <label for="cr-first-name2_4851476384792477">
-                        Card number
-                    </label>
-                    <input type="text" name="company-account" id="company-account" class="accountinput" placeholder="">
-                </div>
+    <div class="row cr-question cr-question-last account-number-row">
+        <div class="span3 cr-label cr-question-left">
+            <label for="cr-first-name2_4851476384792477">
+                Last four digits of Social Security Number
+            </label>
+            <input type="text" name="company-account" id="company-account" class="accountinput zipinput" placeholder="">
+        </div>
 
-                <div class="span2 cr-label cr-question-right right-helper">
-                    <p>This number is on the front of your card</p>
-                </div>
-            </div>
+        <div class="span2 cr-label cr-question-right right-helper">
+            <p></p>
+        </div>
+    </div>
+</fieldset>
 
+<fieldset class="cr-fieldset identify-options debt-collection-phone-number in-repository">
 
-    </fieldset>
+    <div class="row cr-question cr-question-last account-number-row">
+        <div class="span3 cr-label cr-question-left">
+            <label for="cr-first-name2_4851476384792477">
+                Phone number
+            </label>
+            <input type="text" name="company-account" id="company-account" class="accountinput" placeholder="">
+        </div>
 
-     <fieldset class="cr-fieldset identify-options account-number in-repository">
+        <div class="span2 cr-label cr-question-right right-helper">
+            <p>The phone number that has been receiving calls from this debt collector.</p>
+        </div>
+    </div>
+</fieldset>
 
-            <div class="row cr-question cr-question-last account-number-row">
-                <div class="span3 cr-label cr-question-left">
-                    <label for="cr-first-name2_4851476384792477">
-                        Account number
-                    </label>
-                    <input type="text" name="company-account" id="company-account" class="accountinput" placeholder="">
-                </div>
-
-                <div class="span2 cr-label cr-question-right right-helper">
-                    <p>This number is on your billing statements</p>
-                </div>
-            </div>
-
-
-    </fieldset>
-
-
-
-
-     <fieldset class="cr-fieldset identify-options loan-number in-repository">
-
-            <div class="row cr-question cr-question-last account-number-row">
-                <div class="span3 cr-label cr-question-left">
-                    <label for="cr-first-name2_4851476384792477">
-                        Loan number
-                    </label>
-                    <input type="text" name="company-account" id="company-account" class="accountinput" placeholder="">
-                </div>
-
-                <div class="span2 cr-label cr-question-right right-helper">
-                    <p>This number is on your loan documents</p>
-                </div>
-            </div>
-
-
-    </fieldset>
-
-
-     <fieldset class="cr-fieldset identify-options transaction-number in-repository">
-
-            <div class="row cr-question cr-question-last account-number-row">
-                <div class="span3 cr-label cr-question-left">
-                    <label for="cr-first-name2_4851476384792477">
-                        Transaction number
-                    </label>
-                    <input type="text" name="company-account" id="company-account" class="accountinput" placeholder="">
-                </div>
-
-                <div class="span2 cr-label cr-question-right right-helper">
-                    <p>This number is on your transaction receipt</p>
-                </div>
-            </div>
-
-
-    </fieldset>
-
-
-     <fieldset class="cr-fieldset identify-options social-security-number in-repository">
-
-            <div class="row cr-question cr-question-last account-number-row">
-                <div class="span3 cr-label cr-question-left">
-                    <label for="cr-first-name2_4851476384792477">
-                        Social security number
-                    </label>
-                    <input type="text" name="company-account" id="company-account" class="accountinput" placeholder="">
-                </div>
-
-                <div class="span2 cr-label cr-question-right right-helper">
-                    <p>Use format<br/>XXX-XX-XXXX</p>
-                </div>
-            </div>
-
-
-    </fieldset>
-
-
-
-     <fieldset class="cr-fieldset identify-options social-security-last-four in-repository">
-
-            <div class="row cr-question cr-question-last account-number-row">
-                <div class="span3 cr-label cr-question-left">
-                    <label for="cr-first-name2_4851476384792477">
-                        Last four digits of Social Security Number
-                    </label>
-                    <input type="text" name="company-account" id="company-account" class="accountinput zipinput" placeholder="">
-                </div>
-
-                <div class="span2 cr-label cr-question-right right-helper">
-                    <p></p>
-                </div>
-            </div>
-
-
-    </fieldset>
-
-
-
-     <fieldset class="cr-fieldset identify-options debt-collection-phone-number in-repository">
-
-            <div class="row cr-question cr-question-last account-number-row">
-                <div class="span3 cr-label cr-question-left">
-                    <label for="cr-first-name2_4851476384792477">
-                        Phone number
-                    </label>
-                    <input type="text" name="company-account" id="company-account" class="accountinput" placeholder="">
-                </div>
-
-                <div class="span2 cr-label cr-question-right right-helper">
-                    <p>The phone number that has been receiving calls from this debt collector.</p>
-                </div>
-            </div>
-
-
-    </fieldset>
-
- </div>
+</div>
 
 <!--
 
@@ -1656,139 +1418,129 @@ MOBILE WALLET OPTIONS.
 -->
 <script>
 
-if(!window.env){
-    setTimeout(function(){
-        var product = localStorage.getItem("product_selected");
-        var subproduct = localStorage.getItem("subproduct_selected");
-        var issue = localStorage.getItem("issue_selected");
+    if(!window.env){
+        setTimeout(function(){
+            var product = localStorage.getItem("product_selected");
+            var subproduct = localStorage.getItem("subproduct_selected");
+            var issue = localStorage.getItem("issue_selected");
 
-/*         alert(product + ', ' + subproduct + ', ' + issue); */
+            /*         alert(product + ', ' + subproduct + ', ' + issue); */
+            switch (product) {
 
-
-        switch (product) {
-
-            case 'mortgage':
+                case 'mortgage':
                 $('#company-intro-1').text('Mortgage company');
                 $('#company-type-1').show();
                 $('#identify-mortgage-company').appendTo('#company-type-1');
                 break;
 
-            case 'student_loan':
+                case 'student_loan':
                 $('#company-intro-1').text('Student loan company');
                 $('#company-type-1').show();
                 $('#identify-student-loan-company').appendTo('#company-type-1');
                 break
 
-            case 'vehicle_loan':
+                case 'vehicle_loan':
                 $('#company-intro-1').text('Vehicle loan company');
                 $('#company-type-1').show();
                 $('#identify-vehicle-loan-company').appendTo('#company-type-1');
                 break
 
-            case 'consumer_loan':
+                case 'consumer_loan':
                 $('#company-intro-1').text('Company information');
                 $('#company-type-1').show();
                 $('#identify-storefront-services-company').appendTo('#company-type-1');
                 break
 
-            case 'card':
+                case 'card':
                 $('#company-intro-1').text('Card information');
                 $('#company-type-1').show();
                 $('#identify-most-prepaids-company').appendTo('#company-type-1');
                 break
 
-            case 'checking':
+                case 'checking':
                 $('#company-intro-1').text('Bank information');
                 $('#company-type-1').show();
                 $('#identify-checking-savings-company').appendTo('#company-type-1');
                 break
 
-            case 'money_trans':
+                case 'money_trans':
                 $('#company-intro-1').text('Company information');
                 $('#company-type-1').show();
                 $('#identify-money-transfer-company').appendTo('#company-type-1');
                 break
 
-            case 'credit_reporting':
+                case 'credit_reporting':
                 $('#company-intro-1').text('Credit reporting company');
                 $('#company-type-1').show();
                 $('#identify-credit-reporting-company').appendTo('#company-type-1');
                 break
 
-            case 'debt':
+                case 'debt':
                 $('#company-intro-1').text('Debt collection company');
                 $('#company-type-1').show();
                 $('#identify-debt-collection-company').appendTo('#company-type-1');
                 break
 
-            default:
+                default:
                 $('#company-intro-1').text('Company information');
                 $('#company-type-1').show();
                 $('#company-type-2').hide();
 
-        }
+            }
+            switch (subproduct) {
 
-
-        switch (subproduct) {
-
-            case 'credit-repair':
+                case 'credit-repair':
                 $('#company-intro-1').text('Credit repair company');
                 $('#company-type-1').show();
                 $('#identify-credit-reporting-company').remove();
                 $('#identify-credit-debt-repair-company').appendTo('#company-type-1');
                 break
 
-            case 'debt-settlement':
+                case 'debt-settlement':
                 $('#company-intro-1').text('Debt settlement company');
                 $('#company-type-1').show();
                 $('#identify-money-transfer-company').remove();
                 $('#identify-credit-debt-repair-company').appendTo('#company-type-1');
                 break
 
-            case 'domestic-money-transfer':
+                case 'domestic-money-transfer':
                 $('#company-intro-1').text('Money transfer company');
                 $('#company-type-1').show();
                 break
 
-            case 'international-money-transfer':
+                case 'international-money-transfer':
                 $('#company-intro-1').text('Money transfer company');
                 $('#company-type-1').show();
                 break
 
-            case 'foreign-currency-exchange':
+                case 'foreign-currency-exchange':
                 $('#company-intro-1').text('Currency exchange company');
                 $('#company-type-1').show();
                 $('#identify-credit-reporting-company').remove();
                 $('#identify-storefront-services-company').appendTo('#company-type-1');
+            }
+            switch (issue) {
 
-
-        }
-
-
-        switch (issue) {
-
-            case 'debt_collection':
+                case 'debt_collection':
                 $('#company-intro-2').text('Debt collection company');
                 $('#company-type-2').show();
                 $('#identify-debt-collection-company').appendTo('#company-type-2');
                 break;
 
-            case 'credit_reporting':
+                case 'credit_reporting':
                 $('#company-intro-2').text('Credit reporting company');
                 $('#company-type-2').show();
                 $('#identify-credit-reporting-company').appendTo('#company-type-2');
                 break
 
-            default:
+                default:
                 $('#company-type-2').hide();
-        }
-
-
+            }
 /*
         if ( $('.company-name-input').val()) {
         $(this).closest('.identify-product-options').slideDown(200);
         }
-*/
+        */
 
     }, 11);
 }
@@ -1796,16 +1548,14 @@ if(!window.env){
 
 <script>
 
-/*         var announceissue = localStorage.getItem("issue_selected").text()); */
-/*         alert(announceissue); */
-/*         $('.select-product-or-issue').hide(); */
+    /*         var announceissue = localStorage.getItem("issue_selected").text()); */
+    /*         alert(announceissue); */
+    /*         $('.select-product-or-issue').hide(); */
 
 </script>
 
-            <!-- /.primary -->
+<!-- /.primary -->
 </div> <!-- select product -->
-
-
 <!-- options below form -->
 <div class="row cr-continue">
   <a id="continue-button" href="your-information.html"><button class="btn btn-arrow" type="button">Continue</button></a>
@@ -1813,16 +1563,14 @@ if(!window.env){
 </div>
 <!-- /options below form -->
 
-
-
-        </section>
-        <!-- /.row -->
+</section>
+<!-- /.row -->
 
 <!-- =============
      / END CONTENT
      ============= -->
 
-    </div><!-- .wrapper-container -->
+ </div><!-- .wrapper-container -->
 
 </div><!-- .wrapper-body -->
 
@@ -1862,34 +1610,34 @@ if(!window.env){
 
 <!-- TODO: Remove inline styling and scripting. -->
 <style type="text/css">
-.brand h1 {
-    background: transparent url(v0/form/img/money_@2_alt.png) scroll no-repeat left center;
-    background-size:46px;
-}
+    .brand h1 {
+        background: transparent url(v0/form/img/money_@2_alt.png) scroll no-repeat left center;
+        background-size:46px;
+    }
 </style>
 
 <style type="text/css">
-#_cur{
-    position:absolute;
-    top:0px;
-    left:0px;
-    z-index:100000;
-    width:10px;
-    height:10px;
-    margin-left: -8px;
-    margin-top: -8px;
-    left: -10px;
-    top:-10px;
-    background:transparent;
-    opacity:.9;
-    border-radius:100%;
-    border:4px solid rgba(255,255,255,.6);
-}
+    #_cur{
+        position:absolute;
+        top:0px;
+        left:0px;
+        z-index:100000;
+        width:10px;
+        height:10px;
+        margin-left: -8px;
+        margin-top: -8px;
+        left: -10px;
+        top:-10px;
+        background:transparent;
+        opacity:.9;
+        border-radius:100%;
+        border:4px solid rgba(255,255,255,.6);
+    }
 
-#_cur.clk{
-    border:4px dotted black;
-    background: transparent;
-}
+    #_cur.clk{
+        border:4px dotted black;
+        background: transparent;
+    }
 </style>
 
 <script type="text/javascript">


### PR DESCRIPTION
In the form that appears in step 4 when a matching company isn't found in the system, an additional field, phone number, is needed.

## Additions

- Phone number field to the "Currently, this company isn’t signed up to receive complaints through our system" sections of step 4

## Testing

- In step 4, enter a company that isn't in the typeahead data, like "Some New Company"
- In the "Currently, this company isn’t signed up to receive complaints through our system" section that then appears, a "Phone number" field should be right next to the "Website" field.

## Review

- @anselmbradford 

## Screenshots

![company-phone](https://cloud.githubusercontent.com/assets/1862695/15725095/305af214-2818-11e6-8611-1b8ee2daa628.png)

## Todos

- We probably need to reorganize these fields to be in a more logical order soon