### PR TITLE
Add follow-up mortgage questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
   (temporarily; the old code will be phased out as it is
   iteratively replaced with new code).
 - Installation and usage instructions to the readme.
+- Capital Framework project infrastructure (including a gulp build)
+- Old prototype files into new Capital Framework structure (temporarily; the old code will be phased out as it is iteratively replaced with new code)
+- Installation and usage instructions to the readme
+- Follow-up questions for complaints where the issue is "Problems with the mortgage servicer when you are making payments" or "Problems with the mortgage servicer when you are unable to pay"
 
 ### Changed
 - Moved /source-art/ folder to project root so it doesn't get copied to /dist/.

--- a/src/select-issue.html
+++ b/src/select-issue.html
@@ -1480,7 +1480,7 @@ STOP ALL OF THE ISSUE LISTS
         </h3>
 
         <h3 id="mortgage_servicer_paymentslabel" for="select_subissue" class="subissue_label label_same_as_header mortgage_servicer_making_payments_subissues mortgage_servicer_unable_pay_subissues">
-            Have you missed any mortgage payments or are you in default on your mortgage?
+            Are you concerned about losing your home to foreclosure?
         </h3>
 
         <h3 id="debt_collection_labelv" for="select_subissue" class="last product subissue_label product_debt debt_collection_subissues label_same_as_header">
@@ -1713,54 +1713,100 @@ END OF ZOMBIE CREDIT REPORTING TOPLEVEL
 
 <!-- Mortgage servicer subissues -->
 
-<div id="mortgage_servicer_making_payments_subissues" class="issuelist-grid all-subissues">
-  <label class="radio block">
-    <input name="radio_" type="radio" class="radio_input subissue mortgage_servicer_missed_payments" id="mortgage_servicer_missed_payments_yes" />
-    Yes
-    <br /><small>Check “yes” if your mortgage company believes you are in default or have missed payments even if you believe the company is in error.</small>
-  </label>
-  <label class="radio block">
-    <input name="radio_" type="radio" class="radio_input subissue mortgage_servicer_missed_payments" id="mortgage_servicer_missed_payments_no" />
-    No
-    <br /><small></small>
-  </label>
+<div class="subissue_label label_same_as_header mortgage_servicer_making_payments_subissues mortgage_servicer_unable_pay_subissues">
+    <div class="mortgage-servicer-subissue-question mortgage-servicer-subissue-question__radio" id="mortgage_servicer_foreclosure">
+        <p>
+            Please note: submitting a complaint will not automatically delay or stop a foreclosure.
+        </p>
+        <div class="issuelist-grid all-subissues mortgage_servicer_making_payments_subissues mortgage_servicer_unable_pay_subissues">
+          <label class="radio block">
+            <input name="radio_mortgage_servicer_foreclosure" type="radio" class="radio_input subissue" value="yes" />
+            Yes
+          </label>
+          <label class="radio block">
+            <input name="radio_mortgage_servicer_foreclosure" type="radio" class="radio_input subissue" value="no" />
+            No
+          </label>
+        </div>
+    </div>
+
+    <div class="mortgage-servicer-subissue-question mortgage-servicer-subissue-question__radio" id="mortgage_servicer_missed_payments">
+        <h3>
+            Have you missed any mortgage payments or are you in default on your mortgage?
+        </h3>
+        <div class="issuelist-grid all-subissues mortgage_servicer_making_payments_subissues mortgage_servicer_unable_pay_subissues">
+          <label class="radio block">
+            <input name="radio_mortgage_servicer_missed_payments" type="radio" class="radio_input subissue" value="yes" />
+            Yes
+            <br /><small>Check “yes” if your mortgage company believes you are in default or have missed payments even if you believe the company is in error.</small>
+          </label>
+          <label class="radio block">
+            <input name="radio_mortgage_servicer_missed_payments" type="radio" class="radio_input subissue" value="no" />
+            No
+          </label>
+        </div>
+    </div>
+
+    <div class="mortgage-servicer-subissue-question mortgage-servicer-subissue-question__radio mortgage-servicer-subissue-question__followup" id="mortgage_servicer_date_set" data-followup-to="mortgage_servicer_missed_payments">
+        <h3>
+            Is there a date scheduled for the foreclosure sale of your home?
+        </h3>
+        <div class="issuelist-grid all-subissues mortgage_servicer_making_payments_subissues mortgage_servicer_unable_pay_subissues">
+          <label class="radio block">
+            <input name="radio_mortgage_servicer_date_set" type="radio" class="radio_input subissue" value="yes" />
+            Yes
+          </label>
+          <label class="radio block">
+            <input name="radio_mortgage_servicer_date_set" type="radio" class="radio_input subissue" value="no" />
+            No
+          </label>
+        </div>
+        <div class="mortgage-servicer-subissue-question mortgage-servicer-subissue-question__followup mortgage-servicer-subissue-question__text row" id="mortgage_servicer_date" data-followup-to="mortgage_servicer_date_set">
+            <div class="cr-label cr-question-left cr-question-with-sidebar">
+                <label for="foreclosure-date">
+                    When is the scheduled foreclosure sale?
+                </label>
+                <input type="text" class="input-large left" placeholder="mm/dd/yyyy">
+            </div>
+
+            <div class="cr-label cr-question-right right-helper">
+                <p>
+                    You may find this date on the “Notice of Sale” or “Order Setting Sale.”
+                </p>
+            </div>
+        </div>
+    </div>
+
+    <div class="mortgage-servicer-subissue-question mortgage-servicer-subissue-question__radio mortgage-servicer-subissue-question__followup" id="mortgage_servicer_pay_company" data-followup-to="mortgage_servicer_foreclosure mortgage_servicer_missed_payments">
+        <h3>
+            Did you pay a company to help you avoid foreclosure?
+        </h3>
+        <p>
+            Sometimes called ‘foreclosure rescue,’ ‘foreclosure defense,’ ‘foreclosure prevention,’ or ‘loss mitigation assistance’
+        </p>
+        <div class="issuelist-grid all-subissues mortgage_servicer_making_payments_subissues mortgage_servicer_unable_pay_subissues">
+          <label class="radio block">
+            <input name="radio_mortgage_servicer_pay_company" type="radio" class="radio_input subissue" value="yes" />
+            Yes
+          </label>
+          <label class="radio block">
+            <input name="radio_mortgage_servicer_pay_company" type="radio" class="radio_input subissue" value="no" />
+            No
+          </label>
+        </div>
+        <div class="mortgage-servicer-subissue-question mortgage-servicer-subissue-question__followup mortgage-servicer-subissue-question__text row" id="mortgage_servicer_company_name" data-followup-to="mortgage_servicer_pay_company">
+            <div class="cr-label cr-question-left cr-question-with-sidebar">
+                <label for="foreclosure-company-name">
+                    What is the name of the company you paid to avoid foreclosure?
+                </label>
+                <input type="text" id="foreclosure-company-name" class="input-large left">
+            </div>
+        </div>
+    </div>
+
 </div>
 
-<div id="mortgage_servicer_unable_pay_subissues" class="issuelist-grid all-subissues">
-  <label class="radio block">
-    <input name="radio_" type="radio" class="radio_input subissue mortgage_servicer_missed_payments" id="mortgage_servicer_missed_payments_yes" />
-    Yes
-    <br /><small>Check “yes” if your mortgage company believes you are in default or have missed payments even if you believe the company is in error.</small>
-  </label>
-  <label class="radio block">
-    <input name="radio_" type="radio" class="radio_input subissue mortgage_servicer_missed_payments" id="mortgage_servicer_missed_payments_no" />
-    No
-    <br /><small></small>
-  </label>
-</div>
-
-<!--
-<div class="mortgage_servicer_making_payments_subissues mortgage_servicer_unable_pay_subissues">
-  <div class="span3 cr-label">
-    <h3 id="mortgage_servicer_concerned_foreclosure_label" for="select_subissue" class="subissue_label label_same_as_header mortgage_servicer_making_payments_subissues mortgage_servicer_unable_pay_subissues">
-        Are you concerned about losing your home to foreclosure?
-    </h3>
-  </div>
-</div>
-<div class="mortgage_servicer_making_payments_subissues mortgage_servicer_unable_pay_subissues">
-  <label class="radio block">
-    <input name="radio_" type="radio" class="radio_input subissue mortgage_servicer_losing_home" id="mortgage_servicer_losing_home_yes" />
-    Yes
-    <br /><small>Please note: submitting a complaint will not automatically delay or stop a foreclosure.</small>
-  </label>
-  <label class="radio block">
-    <input name="radio_" type="radio" class="radio_input subissue mortgage_servicer_losing_home" id="mortgage_servicer_losing_home_no" />
-    No
-    <br /><small></small>
-  </label>
-</div>
--->
-
+<!-- Vehicle loan subissues -->
 
 <div id="vehicle_loan_shopping_subissues" class="select-product-or-issue issuelist-grid all-subissues">
 

--- a/src/v0/form/css/complain.css
+++ b/src/v0/form/css/complain.css
@@ -1616,7 +1616,6 @@ column-break-inside:avoid;
 
 .cruxform .subproduct-list {
 /* 	width: 600px; */
-
 }
 
 /*
@@ -1723,8 +1722,41 @@ cruxform input.company-name-input {
 
 */
 
+/* ==========================================================================
+   Mortgage follow-up questions
+   ========================================================================== */
+
+.cruxform .subissue_label.mortgage_servicer_making_payments_subissues.mortgage_servicer_unable_pay_subissues {
+    margin-top: -8px;
+}
+
+.cruxform .mortgage-servicer-subissue-question__text {
+    border-top: 1px dashed #ccc;
+    margin-top: 20px;
+}
+
+.cruxform .mortgage-servicer-subissue-question .cr-question-left {
+    width: 402px;
+}
+
+.cruxform .mortgage-servicer-subissue-question .cr-question-left label {
+    padding-left: 0;
+    border: none;
+    margin-left: 0;
+    background-color: transparent;
+}
+
+.cruxform .mortgage-servicer-subissue-question .cr-question-left input {
+    margin-left: 0;
+}
+
+
 .company_verification_fieldset .cr-question {
 	padding-left: 20px;
+}
+
+.mortgage-servicer-subissue-question__followup {
+    display: none;
 }
 
 .company-name-option {
@@ -1934,7 +1966,6 @@ button.secondary {
 
 #scrubbed-narrative span.redacted-text {
 	background: #75787B;
-
 }
 
 #no-email-address-checkbox {
@@ -2006,7 +2037,6 @@ button.secondary {
 	width: 18%;
 	float: left;
     margin-top: 24px;
-
 }
 
 #narrative-consent-take-two {
@@ -2044,7 +2074,6 @@ button.secondary {
 #attachment-drag-instructions {
 	font-size: 20px;
     color: #75787B;
-
 }
 
 #upload-button {

--- a/src/v0/form/js/main.js
+++ b/src/v0/form/js/main.js
@@ -401,11 +401,11 @@ $('.resolution-options').hide();
 		$('.all-subissues').hide();
 		$('.debt-collection-zombie').hide();
 		$('.credit-reporting-zombie').hide();
-		$('h3.subissue_label').hide();
+		$('.subissue_label').hide();
 		$('#zombie_subissues_sublabel').hide();
 		var subissuetype = $(this).attr('id');
 		$('#select_issue label.active').removeClass('active');
-        $('h3.' + $(this).attr('id') + '_subissues').fadeIn('fast');
+        $('.' + $(this).attr('id') + '_subissues').fadeIn('fast');
         $('#' + $(this).attr('id') + '_subissues').slideDown(200);
         $(this).closest('label').addClass('active');
       }
@@ -429,7 +429,7 @@ $('.resolution-options').hide();
     $('.all-subissues .radio_input').on('change', function(){
 
       if ( $('.radio_input').is(':checked') ) {
-        $('.all-subissues label').removeClass('active');
+        $(this).parents('.all-subissues').find('label').removeClass('active');
         $(this).closest('label').addClass('active');
       }
     });
@@ -447,6 +447,35 @@ $('.resolution-options').hide();
   $('.resolution-attempt').on('change', function(){
       $(this).closest('label').toggleClass('active');
   });
+
+/**
+ * Shows and hides mortgage subissue followup questions based on answers to
+ * preceeding trigger questions
+ */
+$( '.mortgage-servicer-subissue-question__radio' ).on( 'change', '.radio_input', function() {
+  var mortageQuestionModel = {};
+  var thisQuestionID = $( this ).parents( '.mortgage-servicer-subissue-question__radio' ).attr('id');
+  var $folowupQuestions = $( '[data-followup-to*="' + thisQuestionID + '"]' );
+  $( '.mortgage-servicer-subissue-question__radio' ).each( function() {
+    var questionID = $( this ).attr( 'id' );
+    var questionValue = $(this).find( '.radio_input:checked' ).val();
+    mortageQuestionModel[ questionID ] = questionValue;
+  } );
+  $folowupQuestions.each( function() {
+    var $question = $( this );
+    var triggerQuestionIDs = $question.attr( 'data-followup-to' ).split( ' ' );
+    // If ANY of the follow-up question's triggers are answered "yes", show the
+    // follow-up. Otherwise, hide the follow-up.
+    for (var i = 0; i < triggerQuestionIDs.length; i++) {
+      var triggerAnswer = mortageQuestionModel[ triggerQuestionIDs[ i ] ];
+      if ( triggerAnswer === 'yes' ) {
+        $question.slideDown();
+        break;
+      }
+      $question.slideUp();
+    };
+  } );
+} );
 
 /*
 ///


### PR DESCRIPTION
Add follow-up questions for mortgage complaints

## Additions

- Follow-up questions for mortgage complaints when the issue selected is either "problems with the mortgage servicer when you are making payments" or "problems with the mortgage servicer when you are unable to pay"

## Removals

- Outdated versions of mortgage follow-up questions

## Changes

- Fixed how the `active` class is applied to accommodate multiple sub-issue questions 

## Testing

1. On step 1, select "Mortgage" as the product and "Home mortgage" as the sub-product
2. On step 2, select either "problems with the mortgage servicer when you are making payments" or "problems with the mortgage servicer when you are unable to pay" as the issue
3. You should see two follow-up questions. Up to six follow-up questions will appear depending on how you answer the questions, like so:
  1. Are you concerned about losing your home to foreclosure? [Yes/No]
  2. Have you missed any mortgage payments or are you in default on your mortgage [Yes/No]
  3. (If yes to question 2) Is there a date scheduled for the foreclosure sale of your home? [Yes/No]
  4. (If yes to question 3) When is the scheduled foreclosure sale? [Date]
  5. (If yes to question 1 or question 2): Did you pay a company to help you avoid foreclosure? [Yes/No]
  6. (If yes to question 5): What is the name of the company you paid to avoid foreclosure? [Yes/No]
4. Changing answers to any of the questions should hide or show the relevant follow-ups

## Review

- @anselmbradford 

## Screenshots

![mortgage-followups](https://cloud.githubusercontent.com/assets/1862695/15861740/53a145ac-2c9b-11e6-8460-560a08b861c3.png)