### PR TITLE
Converted state text inputs to drop-downs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Old prototype files into new Capital Framework structure (temporarily; the old code will be phased out as it is iteratively replaced with new code)
 - Installation and usage instructions to the readme
 - Phone number field to the form that appears when a matching company isn't found in the system in step 4
-
-### Changed
 - For debt collecction complaints, the phone number the debt collector is calling is now a separate field from the other consumer identifiers in step 4
+- Converted company-information.html state text inputs to drop-downs.
 
 ### Deprecated
 - Nothing.

--- a/src/company-information.html
+++ b/src/company-information.html
@@ -211,15 +211,80 @@ COMPANY-1
                         <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
                     </div>
 
-                    <!-- suffix -->
+                    <!-- state -->
                     <div class="span2 cr-label cr-question-right">
-                        <label for="cr-suffix2">
+                        <label for="state1">
                             State
                             <small class="inline"></small>
                         </label>
-                        <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
+
+                        <select name="cr-suffix" id="state1" class="block">
+                            <option value="" disabled="disabled" selected="selected">Select a state...</option>
+                            <option label="Alabama" value="2" >Alabama</option>
+                            <option label="Alaska" value="1" >Alaska</option>
+                            <option label="American Samoa" value="4" >American Samoa</option>
+                            <option label="Arizona" value="5" >Arizona</option>
+                            <option label="Arkansas" value="3" >Arkansas</option>
+                            <option label="California" value="6" >California</option>
+                            <option label="Colorado" value="7" >Colorado</option>
+                            <option label="Connecticut" value="8" >Connecticut</option>
+                            <option label="Delaware" value="10" >Delaware</option>
+                            <option label="District Of Columbia" value="9" >District Of Columbia</option>
+                            <option label="Federated States Of Micronesia" value="12" >Federated States Of Micronesia</option>
+                            <option label="Florida" value="11" >Florida</option>
+                            <option label="Georgia" value="13" >Georgia</option>
+                            <option label="Guam" value="14" >Guam</option>
+                            <option label="Hawaii" value="15" >Hawaii</option>
+                            <option label="Idaho" value="17" >Idaho</option>
+                            <option label="Illinois" value="18" >Illinois</option>
+                            <option label="Indiana" value="19" >Indiana</option>
+                            <option label="Iowa" value="16" >Iowa</option>
+                            <option label="Kansas" value="20" >Kansas</option>
+                            <option label="Kentucky" value="21" >Kentucky</option>
+                            <option label="Louisiana" value="22" >Louisiana</option>
+                            <option label="Maine" value="25" >Maine</option>
+                            <option label="Marshall Islands" value="26" >Marshall Islands</option>
+                            <option label="Maryland" value="24" >Maryland</option>
+                            <option label="Massachusetts" value="23" >Massachusetts</option>
+                            <option label="Michigan" value="27" >Michigan</option>
+                            <option label="Minnesota" value="28" >Minnesota</option>
+                            <option label="Mississippi" value="31" >Mississippi</option>
+                            <option label="Missouri" value="29" >Missouri</option>
+                            <option label="Montana" value="32" >Montana</option>
+                            <option label="Nebraska" value="35" >Nebraska</option>
+                            <option label="Nevada" value="39" >Nevada</option>
+                            <option label="New Hampshire" value="36" >New Hampshire</option>
+                            <option label="New Jersey" value="37" >New Jersey</option>
+                            <option label="New Mexico" value="38" >New Mexico</option>
+                            <option label="New York" value="40" >New York</option>
+                            <option label="North Carolina" value="33" >North Carolina</option>
+                            <option label="North Dakota" value="34" >North Dakota</option>
+                            <option label="Northern Mariana Islands" value="30" >Northern Mariana Islands</option>
+                            <option label="Ohio" value="41" >Ohio</option>
+                            <option label="Oklahoma" value="42" >Oklahoma</option>
+                            <option label="Oregon" value="43" >Oregon</option>
+                            <option label="Palau" value="46" >Palau</option>
+                            <option label="Pennsylvania" value="44" >Pennsylvania</option>
+                            <option label="Puerto Rico" value="45" >Puerto Rico</option>
+                            <option label="Rhode Island" value="47" >Rhode Island</option>
+                            <option label="South Carolina" value="48" >South Carolina</option>
+                            <option label="South Dakota" value="49" >South Dakota</option>
+                            <option label="Tennessee" value="50" >Tennessee</option>
+                            <option label="Texas" value="51" >Texas</option>
+                            <option label="Utah" value="52" >Utah</option>
+                            <option label="Vermont" value="55" >Vermont</option>
+                            <option label="Virgin Islands" value="54" >Virgin Islands</option>
+                            <option label="Virginia" value="53" >Virginia</option>
+                            <option label="Washington" value="56" >Washington</option>
+                            <option label="West Virginia" value="58" >West Virginia</option>
+                            <option label="Wisconsin" value="57" >Wisconsin</option>
+                            <option label="Wyoming" value="59" >Wyoming</option>
+                            <option label="Armed Forces Middle East" value="95" >Armed Forces Middle East</option>
+                            <option label="Armed Forces Americas" value="94" >Armed Forces Americas</option>
+                            <option label="Armed Forces Pacific" value="96" >Armed Forces Pacific</option>
+                        </select>
                     </div>
-                    <!-- /suffix -->
+                    <!-- /state -->
                 </div>
                 <!-- /city and state -->
                 <div class="row cr-question">
@@ -260,7 +325,6 @@ COMPANY-1
 End company-1
 ///////////
 -->
-
 
 <!--
 ///////////
@@ -342,15 +406,80 @@ COMPANY-2
                     <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
                 </div>
 
-                <!-- suffix -->
+                <!-- state -->
                 <div class="span2 cr-label cr-question-right">
-                    <label for="cr-suffix2">
+                    <label for="state2">
                         State
                         <small class="inline"></small>
                     </label>
-                    <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
+
+                    <select name="cr-suffix" id="state2" class="block">
+                        <option value="" disabled="disabled" selected="selected">Select a state...</option>
+                        <option label="Alabama" value="2" >Alabama</option>
+                        <option label="Alaska" value="1" >Alaska</option>
+                        <option label="American Samoa" value="4" >American Samoa</option>
+                        <option label="Arizona" value="5" >Arizona</option>
+                        <option label="Arkansas" value="3" >Arkansas</option>
+                        <option label="California" value="6" >California</option>
+                        <option label="Colorado" value="7" >Colorado</option>
+                        <option label="Connecticut" value="8" >Connecticut</option>
+                        <option label="Delaware" value="10" >Delaware</option>
+                        <option label="District Of Columbia" value="9" >District Of Columbia</option>
+                        <option label="Federated States Of Micronesia" value="12" >Federated States Of Micronesia</option>
+                        <option label="Florida" value="11" >Florida</option>
+                        <option label="Georgia" value="13" >Georgia</option>
+                        <option label="Guam" value="14" >Guam</option>
+                        <option label="Hawaii" value="15" >Hawaii</option>
+                        <option label="Idaho" value="17" >Idaho</option>
+                        <option label="Illinois" value="18" >Illinois</option>
+                        <option label="Indiana" value="19" >Indiana</option>
+                        <option label="Iowa" value="16" >Iowa</option>
+                        <option label="Kansas" value="20" >Kansas</option>
+                        <option label="Kentucky" value="21" >Kentucky</option>
+                        <option label="Louisiana" value="22" >Louisiana</option>
+                        <option label="Maine" value="25" >Maine</option>
+                        <option label="Marshall Islands" value="26" >Marshall Islands</option>
+                        <option label="Maryland" value="24" >Maryland</option>
+                        <option label="Massachusetts" value="23" >Massachusetts</option>
+                        <option label="Michigan" value="27" >Michigan</option>
+                        <option label="Minnesota" value="28" >Minnesota</option>
+                        <option label="Mississippi" value="31" >Mississippi</option>
+                        <option label="Missouri" value="29" >Missouri</option>
+                        <option label="Montana" value="32" >Montana</option>
+                        <option label="Nebraska" value="35" >Nebraska</option>
+                        <option label="Nevada" value="39" >Nevada</option>
+                        <option label="New Hampshire" value="36" >New Hampshire</option>
+                        <option label="New Jersey" value="37" >New Jersey</option>
+                        <option label="New Mexico" value="38" >New Mexico</option>
+                        <option label="New York" value="40" >New York</option>
+                        <option label="North Carolina" value="33" >North Carolina</option>
+                        <option label="North Dakota" value="34" >North Dakota</option>
+                        <option label="Northern Mariana Islands" value="30" >Northern Mariana Islands</option>
+                        <option label="Ohio" value="41" >Ohio</option>
+                        <option label="Oklahoma" value="42" >Oklahoma</option>
+                        <option label="Oregon" value="43" >Oregon</option>
+                        <option label="Palau" value="46" >Palau</option>
+                        <option label="Pennsylvania" value="44" >Pennsylvania</option>
+                        <option label="Puerto Rico" value="45" >Puerto Rico</option>
+                        <option label="Rhode Island" value="47" >Rhode Island</option>
+                        <option label="South Carolina" value="48" >South Carolina</option>
+                        <option label="South Dakota" value="49" >South Dakota</option>
+                        <option label="Tennessee" value="50" >Tennessee</option>
+                        <option label="Texas" value="51" >Texas</option>
+                        <option label="Utah" value="52" >Utah</option>
+                        <option label="Vermont" value="55" >Vermont</option>
+                        <option label="Virgin Islands" value="54" >Virgin Islands</option>
+                        <option label="Virginia" value="53" >Virginia</option>
+                        <option label="Washington" value="56" >Washington</option>
+                        <option label="West Virginia" value="58" >West Virginia</option>
+                        <option label="Wisconsin" value="57" >Wisconsin</option>
+                        <option label="Wyoming" value="59" >Wyoming</option>
+                        <option label="Armed Forces Middle East" value="95" >Armed Forces Middle East</option>
+                        <option label="Armed Forces Americas" value="94" >Armed Forces Americas</option>
+                        <option label="Armed Forces Pacific" value="96" >Armed Forces Pacific</option>
+                    </select>
                 </div>
-                <!-- /suffix -->
+                <!-- /state -->
             </div>
             <!-- /city and state -->
             <div class="row cr-question">
@@ -538,17 +667,80 @@ ADDITIONAL COMPANY
                     <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
                 </div>
 
-                <!-- suffix -->
+                <!-- state -->
                 <div class="span2 cr-label cr-question-right">
-                    <label for="cr-suffix2">
+                    <label for="state3">
                         State
                         <small class="inline"></small>
                     </label>
 
-                    <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
-
+                    <select name="cr-suffix" id="state3" class="block">
+                        <option value="" disabled="disabled" selected="selected">Select a state...</option>
+                        <option label="Alabama" value="2" >Alabama</option>
+                        <option label="Alaska" value="1" >Alaska</option>
+                        <option label="American Samoa" value="4" >American Samoa</option>
+                        <option label="Arizona" value="5" >Arizona</option>
+                        <option label="Arkansas" value="3" >Arkansas</option>
+                        <option label="California" value="6" >California</option>
+                        <option label="Colorado" value="7" >Colorado</option>
+                        <option label="Connecticut" value="8" >Connecticut</option>
+                        <option label="Delaware" value="10" >Delaware</option>
+                        <option label="District Of Columbia" value="9" >District Of Columbia</option>
+                        <option label="Federated States Of Micronesia" value="12" >Federated States Of Micronesia</option>
+                        <option label="Florida" value="11" >Florida</option>
+                        <option label="Georgia" value="13" >Georgia</option>
+                        <option label="Guam" value="14" >Guam</option>
+                        <option label="Hawaii" value="15" >Hawaii</option>
+                        <option label="Idaho" value="17" >Idaho</option>
+                        <option label="Illinois" value="18" >Illinois</option>
+                        <option label="Indiana" value="19" >Indiana</option>
+                        <option label="Iowa" value="16" >Iowa</option>
+                        <option label="Kansas" value="20" >Kansas</option>
+                        <option label="Kentucky" value="21" >Kentucky</option>
+                        <option label="Louisiana" value="22" >Louisiana</option>
+                        <option label="Maine" value="25" >Maine</option>
+                        <option label="Marshall Islands" value="26" >Marshall Islands</option>
+                        <option label="Maryland" value="24" >Maryland</option>
+                        <option label="Massachusetts" value="23" >Massachusetts</option>
+                        <option label="Michigan" value="27" >Michigan</option>
+                        <option label="Minnesota" value="28" >Minnesota</option>
+                        <option label="Mississippi" value="31" >Mississippi</option>
+                        <option label="Missouri" value="29" >Missouri</option>
+                        <option label="Montana" value="32" >Montana</option>
+                        <option label="Nebraska" value="35" >Nebraska</option>
+                        <option label="Nevada" value="39" >Nevada</option>
+                        <option label="New Hampshire" value="36" >New Hampshire</option>
+                        <option label="New Jersey" value="37" >New Jersey</option>
+                        <option label="New Mexico" value="38" >New Mexico</option>
+                        <option label="New York" value="40" >New York</option>
+                        <option label="North Carolina" value="33" >North Carolina</option>
+                        <option label="North Dakota" value="34" >North Dakota</option>
+                        <option label="Northern Mariana Islands" value="30" >Northern Mariana Islands</option>
+                        <option label="Ohio" value="41" >Ohio</option>
+                        <option label="Oklahoma" value="42" >Oklahoma</option>
+                        <option label="Oregon" value="43" >Oregon</option>
+                        <option label="Palau" value="46" >Palau</option>
+                        <option label="Pennsylvania" value="44" >Pennsylvania</option>
+                        <option label="Puerto Rico" value="45" >Puerto Rico</option>
+                        <option label="Rhode Island" value="47" >Rhode Island</option>
+                        <option label="South Carolina" value="48" >South Carolina</option>
+                        <option label="South Dakota" value="49" >South Dakota</option>
+                        <option label="Tennessee" value="50" >Tennessee</option>
+                        <option label="Texas" value="51" >Texas</option>
+                        <option label="Utah" value="52" >Utah</option>
+                        <option label="Vermont" value="55" >Vermont</option>
+                        <option label="Virgin Islands" value="54" >Virgin Islands</option>
+                        <option label="Virginia" value="53" >Virginia</option>
+                        <option label="Washington" value="56" >Washington</option>
+                        <option label="West Virginia" value="58" >West Virginia</option>
+                        <option label="Wisconsin" value="57" >Wisconsin</option>
+                        <option label="Wyoming" value="59" >Wyoming</option>
+                        <option label="Armed Forces Middle East" value="95" >Armed Forces Middle East</option>
+                        <option label="Armed Forces Americas" value="94" >Armed Forces Americas</option>
+                        <option label="Armed Forces Pacific" value="96" >Armed Forces Pacific</option>
+                    </select>
                 </div>
-                <!-- /suffix -->
+                <!-- /state -->
 
             </div>
             <!-- /city and state -->
@@ -1189,15 +1381,80 @@ MOBILE WALLET OPTIONS.
             <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
         </div>
 
-        <!-- suffix -->
+        <!-- state -->
         <div class="span2 cr-label cr-question-right">
-            <label for="cr-suffix2">
+            <label for="state4">
                 State
                 <small class="inline"></small>
             </label>
-            <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
+
+            <select name="cr-suffix" id="state4" class="block">
+                <option value="" disabled="disabled" selected="selected">Select a state...</option>
+                <option label="Alabama" value="2" >Alabama</option>
+                <option label="Alaska" value="1" >Alaska</option>
+                <option label="American Samoa" value="4" >American Samoa</option>
+                <option label="Arizona" value="5" >Arizona</option>
+                <option label="Arkansas" value="3" >Arkansas</option>
+                <option label="California" value="6" >California</option>
+                <option label="Colorado" value="7" >Colorado</option>
+                <option label="Connecticut" value="8" >Connecticut</option>
+                <option label="Delaware" value="10" >Delaware</option>
+                <option label="District Of Columbia" value="9" >District Of Columbia</option>
+                <option label="Federated States Of Micronesia" value="12" >Federated States Of Micronesia</option>
+                <option label="Florida" value="11" >Florida</option>
+                <option label="Georgia" value="13" >Georgia</option>
+                <option label="Guam" value="14" >Guam</option>
+                <option label="Hawaii" value="15" >Hawaii</option>
+                <option label="Idaho" value="17" >Idaho</option>
+                <option label="Illinois" value="18" >Illinois</option>
+                <option label="Indiana" value="19" >Indiana</option>
+                <option label="Iowa" value="16" >Iowa</option>
+                <option label="Kansas" value="20" >Kansas</option>
+                <option label="Kentucky" value="21" >Kentucky</option>
+                <option label="Louisiana" value="22" >Louisiana</option>
+                <option label="Maine" value="25" >Maine</option>
+                <option label="Marshall Islands" value="26" >Marshall Islands</option>
+                <option label="Maryland" value="24" >Maryland</option>
+                <option label="Massachusetts" value="23" >Massachusetts</option>
+                <option label="Michigan" value="27" >Michigan</option>
+                <option label="Minnesota" value="28" >Minnesota</option>
+                <option label="Mississippi" value="31" >Mississippi</option>
+                <option label="Missouri" value="29" >Missouri</option>
+                <option label="Montana" value="32" >Montana</option>
+                <option label="Nebraska" value="35" >Nebraska</option>
+                <option label="Nevada" value="39" >Nevada</option>
+                <option label="New Hampshire" value="36" >New Hampshire</option>
+                <option label="New Jersey" value="37" >New Jersey</option>
+                <option label="New Mexico" value="38" >New Mexico</option>
+                <option label="New York" value="40" >New York</option>
+                <option label="North Carolina" value="33" >North Carolina</option>
+                <option label="North Dakota" value="34" >North Dakota</option>
+                <option label="Northern Mariana Islands" value="30" >Northern Mariana Islands</option>
+                <option label="Ohio" value="41" >Ohio</option>
+                <option label="Oklahoma" value="42" >Oklahoma</option>
+                <option label="Oregon" value="43" >Oregon</option>
+                <option label="Palau" value="46" >Palau</option>
+                <option label="Pennsylvania" value="44" >Pennsylvania</option>
+                <option label="Puerto Rico" value="45" >Puerto Rico</option>
+                <option label="Rhode Island" value="47" >Rhode Island</option>
+                <option label="South Carolina" value="48" >South Carolina</option>
+                <option label="South Dakota" value="49" >South Dakota</option>
+                <option label="Tennessee" value="50" >Tennessee</option>
+                <option label="Texas" value="51" >Texas</option>
+                <option label="Utah" value="52" >Utah</option>
+                <option label="Vermont" value="55" >Vermont</option>
+                <option label="Virgin Islands" value="54" >Virgin Islands</option>
+                <option label="Virginia" value="53" >Virginia</option>
+                <option label="Washington" value="56" >Washington</option>
+                <option label="West Virginia" value="58" >West Virginia</option>
+                <option label="Wisconsin" value="57" >Wisconsin</option>
+                <option label="Wyoming" value="59" >Wyoming</option>
+                <option label="Armed Forces Middle East" value="95" >Armed Forces Middle East</option>
+                <option label="Armed Forces Americas" value="94" >Armed Forces Americas</option>
+                <option label="Armed Forces Pacific" value="96" >Armed Forces Pacific</option>
+            </select>
         </div>
-        <!-- /suffix -->
+        <!-- /state -->
     </div>
     <!-- /city and state -->
 </fieldset>
@@ -1228,15 +1485,80 @@ MOBILE WALLET OPTIONS.
             <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
         </div>
 
-        <!-- suffix -->
+        <!-- state -->
         <div class="span2 cr-label cr-question-right">
-            <label for="cr-suffix2">
+            <label for="state5">
                 State
                 <small class="inline"></small>
             </label>
-            <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
+
+            <select name="cr-suffix" id="state5" class="block">
+                <option value="" disabled="disabled" selected="selected">Select a state...</option>
+                <option label="Alabama" value="2" >Alabama</option>
+                <option label="Alaska" value="1" >Alaska</option>
+                <option label="American Samoa" value="4" >American Samoa</option>
+                <option label="Arizona" value="5" >Arizona</option>
+                <option label="Arkansas" value="3" >Arkansas</option>
+                <option label="California" value="6" >California</option>
+                <option label="Colorado" value="7" >Colorado</option>
+                <option label="Connecticut" value="8" >Connecticut</option>
+                <option label="Delaware" value="10" >Delaware</option>
+                <option label="District Of Columbia" value="9" >District Of Columbia</option>
+                <option label="Federated States Of Micronesia" value="12" >Federated States Of Micronesia</option>
+                <option label="Florida" value="11" >Florida</option>
+                <option label="Georgia" value="13" >Georgia</option>
+                <option label="Guam" value="14" >Guam</option>
+                <option label="Hawaii" value="15" >Hawaii</option>
+                <option label="Idaho" value="17" >Idaho</option>
+                <option label="Illinois" value="18" >Illinois</option>
+                <option label="Indiana" value="19" >Indiana</option>
+                <option label="Iowa" value="16" >Iowa</option>
+                <option label="Kansas" value="20" >Kansas</option>
+                <option label="Kentucky" value="21" >Kentucky</option>
+                <option label="Louisiana" value="22" >Louisiana</option>
+                <option label="Maine" value="25" >Maine</option>
+                <option label="Marshall Islands" value="26" >Marshall Islands</option>
+                <option label="Maryland" value="24" >Maryland</option>
+                <option label="Massachusetts" value="23" >Massachusetts</option>
+                <option label="Michigan" value="27" >Michigan</option>
+                <option label="Minnesota" value="28" >Minnesota</option>
+                <option label="Mississippi" value="31" >Mississippi</option>
+                <option label="Missouri" value="29" >Missouri</option>
+                <option label="Montana" value="32" >Montana</option>
+                <option label="Nebraska" value="35" >Nebraska</option>
+                <option label="Nevada" value="39" >Nevada</option>
+                <option label="New Hampshire" value="36" >New Hampshire</option>
+                <option label="New Jersey" value="37" >New Jersey</option>
+                <option label="New Mexico" value="38" >New Mexico</option>
+                <option label="New York" value="40" >New York</option>
+                <option label="North Carolina" value="33" >North Carolina</option>
+                <option label="North Dakota" value="34" >North Dakota</option>
+                <option label="Northern Mariana Islands" value="30" >Northern Mariana Islands</option>
+                <option label="Ohio" value="41" >Ohio</option>
+                <option label="Oklahoma" value="42" >Oklahoma</option>
+                <option label="Oregon" value="43" >Oregon</option>
+                <option label="Palau" value="46" >Palau</option>
+                <option label="Pennsylvania" value="44" >Pennsylvania</option>
+                <option label="Puerto Rico" value="45" >Puerto Rico</option>
+                <option label="Rhode Island" value="47" >Rhode Island</option>
+                <option label="South Carolina" value="48" >South Carolina</option>
+                <option label="South Dakota" value="49" >South Dakota</option>
+                <option label="Tennessee" value="50" >Tennessee</option>
+                <option label="Texas" value="51" >Texas</option>
+                <option label="Utah" value="52" >Utah</option>
+                <option label="Vermont" value="55" >Vermont</option>
+                <option label="Virgin Islands" value="54" >Virgin Islands</option>
+                <option label="Virginia" value="53" >Virginia</option>
+                <option label="Washington" value="56" >Washington</option>
+                <option label="West Virginia" value="58" >West Virginia</option>
+                <option label="Wisconsin" value="57" >Wisconsin</option>
+                <option label="Wyoming" value="59" >Wyoming</option>
+                <option label="Armed Forces Middle East" value="95" >Armed Forces Middle East</option>
+                <option label="Armed Forces Americas" value="94" >Armed Forces Americas</option>
+                <option label="Armed Forces Pacific" value="96" >Armed Forces Pacific</option>
+            </select>
         </div>
-        <!-- /suffix -->
+        <!-- /state -->
     </div>
     <!-- /city and state -->
 </fieldset>
@@ -1269,15 +1591,80 @@ MOBILE WALLET OPTIONS.
             <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
         </div>
 
-        <!-- suffix -->
+        <!-- state -->
         <div class="span2 cr-label cr-question-right">
-            <label for="cr-suffix2">
+            <label for="state6">
                 State
                 <small class="inline"></small>
             </label>
-            <input type="text" name="cr-last-name" id="cr-last-name2_4851476384792477" placeholder="">
+
+            <select name="cr-suffix" id="state6" class="block">
+                <option value="" disabled="disabled" selected="selected">Select a state...</option>
+                <option label="Alabama" value="2" >Alabama</option>
+                <option label="Alaska" value="1" >Alaska</option>
+                <option label="American Samoa" value="4" >American Samoa</option>
+                <option label="Arizona" value="5" >Arizona</option>
+                <option label="Arkansas" value="3" >Arkansas</option>
+                <option label="California" value="6" >California</option>
+                <option label="Colorado" value="7" >Colorado</option>
+                <option label="Connecticut" value="8" >Connecticut</option>
+                <option label="Delaware" value="10" >Delaware</option>
+                <option label="District Of Columbia" value="9" >District Of Columbia</option>
+                <option label="Federated States Of Micronesia" value="12" >Federated States Of Micronesia</option>
+                <option label="Florida" value="11" >Florida</option>
+                <option label="Georgia" value="13" >Georgia</option>
+                <option label="Guam" value="14" >Guam</option>
+                <option label="Hawaii" value="15" >Hawaii</option>
+                <option label="Idaho" value="17" >Idaho</option>
+                <option label="Illinois" value="18" >Illinois</option>
+                <option label="Indiana" value="19" >Indiana</option>
+                <option label="Iowa" value="16" >Iowa</option>
+                <option label="Kansas" value="20" >Kansas</option>
+                <option label="Kentucky" value="21" >Kentucky</option>
+                <option label="Louisiana" value="22" >Louisiana</option>
+                <option label="Maine" value="25" >Maine</option>
+                <option label="Marshall Islands" value="26" >Marshall Islands</option>
+                <option label="Maryland" value="24" >Maryland</option>
+                <option label="Massachusetts" value="23" >Massachusetts</option>
+                <option label="Michigan" value="27" >Michigan</option>
+                <option label="Minnesota" value="28" >Minnesota</option>
+                <option label="Mississippi" value="31" >Mississippi</option>
+                <option label="Missouri" value="29" >Missouri</option>
+                <option label="Montana" value="32" >Montana</option>
+                <option label="Nebraska" value="35" >Nebraska</option>
+                <option label="Nevada" value="39" >Nevada</option>
+                <option label="New Hampshire" value="36" >New Hampshire</option>
+                <option label="New Jersey" value="37" >New Jersey</option>
+                <option label="New Mexico" value="38" >New Mexico</option>
+                <option label="New York" value="40" >New York</option>
+                <option label="North Carolina" value="33" >North Carolina</option>
+                <option label="North Dakota" value="34" >North Dakota</option>
+                <option label="Northern Mariana Islands" value="30" >Northern Mariana Islands</option>
+                <option label="Ohio" value="41" >Ohio</option>
+                <option label="Oklahoma" value="42" >Oklahoma</option>
+                <option label="Oregon" value="43" >Oregon</option>
+                <option label="Palau" value="46" >Palau</option>
+                <option label="Pennsylvania" value="44" >Pennsylvania</option>
+                <option label="Puerto Rico" value="45" >Puerto Rico</option>
+                <option label="Rhode Island" value="47" >Rhode Island</option>
+                <option label="South Carolina" value="48" >South Carolina</option>
+                <option label="South Dakota" value="49" >South Dakota</option>
+                <option label="Tennessee" value="50" >Tennessee</option>
+                <option label="Texas" value="51" >Texas</option>
+                <option label="Utah" value="52" >Utah</option>
+                <option label="Vermont" value="55" >Vermont</option>
+                <option label="Virgin Islands" value="54" >Virgin Islands</option>
+                <option label="Virginia" value="53" >Virginia</option>
+                <option label="Washington" value="56" >Washington</option>
+                <option label="West Virginia" value="58" >West Virginia</option>
+                <option label="Wisconsin" value="57" >Wisconsin</option>
+                <option label="Wyoming" value="59" >Wyoming</option>
+                <option label="Armed Forces Middle East" value="95" >Armed Forces Middle East</option>
+                <option label="Armed Forces Americas" value="94" >Armed Forces Americas</option>
+                <option label="Armed Forces Pacific" value="96" >Armed Forces Pacific</option>
+            </select>
         </div>
-        <!-- /suffix -->
+        <!-- /state -->
     </div>
 
 </fieldset>


### PR DESCRIPTION
## Changes

- Converted company-information.html state text inputs to drop-downs.

## Testing

- `gulp build`
- Visit `/company-information.html`
- Enter a fake company name.
- See State dropdown.

## Review

- @niqjohnson 

## Screenshots

![screen shot 2016-06-08 at 11 28 33 am](https://cloud.githubusercontent.com/assets/704760/15900513/bfb0c13c-2d6d-11e6-925b-66d74de7f45f.png)

![screen shot 2016-06-08 at 11 28 08 am](https://cloud.githubusercontent.com/assets/704760/15900514/bfb11452-2d6d-11e6-96d0-91da1fe0e634.png)

## Notes

- There are six state drop-downs in the source code, but I can't find six when interacting with the form.
