### PR TITLE
Update readme with release instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,22 @@
-All notable changes to this project will be documented in this file.
-We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
-
-
 ## Unreleased
+
+### Added
+- Full address for additional contact.
+
+### Changed
+- Converted company-information.html state text inputs to drop-downs.
+
+### Deprecated
+- Nothing.
+
+### Removed
+- Empty `placeholder` attributes.
+
+### Fixed
+- Nothing.
+
+
+## [v0.52](https://cfpb.github.io/complaint-intake/versions/0.52/)
 
 ### Added
 - Initial repository setup.
@@ -11,11 +25,11 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
   (temporarily; the old code will be phased out as it is
   iteratively replaced with new code).
 - Installation and usage instructions to the readme.
-- Capital Framework project infrastructure (including a gulp build)
-- Old prototype files into new Capital Framework structure (temporarily; the old code will be phased out as it is iteratively replaced with new code)
-- Installation and usage instructions to the readme
-- Follow-up questions for complaints where the issue is "Problems with the mortgage servicer when you are making payments" or "Problems with the mortgage servicer when you are unable to pay"
-- Full address for additional contact.
+- Follow-up questions for complaints where the issue is "Problems with the
+  mortgage servicer when you are making payments" or "Problems with the mortgage
+  servicer when you are unable to pay".
+- Phone number field to the form that appears when a matching company isn't
+  found in the system in step 4
 
 ### Changed
 - Moved /source-art/ folder to project root so it doesn't get copied to /dist/.
@@ -23,22 +37,17 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Updated eslint to 2.0.0.
 - Normalized gulp variable and task naming.
 - Moved form markup to `/src/`.
-- Capital Framework project infrastructure (including a gulp build)
-- Old prototype files into new Capital Framework structure (temporarily; the old code will be phased out as it is iteratively replaced with new code)
-- Installation and usage instructions to the readme
-- Phone number field to the form that appears when a matching company isn't found in the system in step 4
-- For debt collecction complaints, the phone number the debt collector is calling is now a separate field from the other consumer identifiers in step 4
-- Converted company-information.html state text inputs to drop-downs.
+- For debt collecction complaints, the phone number the debt collector is
+  calling is now a separate field from the other consumer identifiers in step 4.
 
 ### Deprecated
 - Nothing.
 
 ### Removed
 - Google Analytics references since GTM is used.
-- Empty `placeholder` attributes.
 
 ### Fixed
 - Two-column lists with an odd number of items no longer spill into a
   third column.
 - The question "What school did you attend when you received the loan?"
-  now reads "What school were you attending when you received the loan?"
+  now reads "What school were you attending when you received the loan?".

--- a/README.md
+++ b/README.md
@@ -42,11 +42,34 @@ Open a **gulp** tab in your terminal and run:
 gulp watch
 ```
 
-That should open a tab in your browser that points to `http://localhost:3000/dist/`. Go to the `v0/` directory there to see the current iteration.
+That should open a tab in your browser that points to `http://localhost:3000/dist/`, where you should see the complaint landing page.
 
 Do all your development on the files in `/src/`. Your browser should automatically refresh the page as you make changes to anything in `/src/`.
 
 Currently, the code lives in `/src/` and references legacy assets in `/src/v0/`. All the pages in there are being iteratively refactored to be more standard Capital Framework pages. Refactored JS and CSS will get moved to `/src/static/`.
+
+## Releases
+
+At the end of each sprint, we release the new iteration by updating the `gh-pages` branch. Here’s the process:
+
+1. Run one final `gulp` to make sure all the changes you want to release are built into the `dist` directory
+2. Make a copy of the `dist` directory somewhere, like your desktop
+3. Rename that copy of `dist` to the version you’re releasing, like `0.52`
+4. `git checkout gh-pages`
+5. Copy everything in your new version directory into the root of `gh-pages`, overwriting the old HTML files and the `static` and `v0` directories there
+6. Move your new version directory into `versions`
+7. `git add .`
+8. `git commit`
+9. `git push origin gh-pages`
+10. Check to make sure the latest version is available at two URLs:
+  - https://cfpb.github.io/complaint-intake/
+  - https://cfpb.github.io/complaint-intake/versions/X.XX/ (where X.XX is the version you’re releasing, like 0.52)
+11. Switch back to `master` (you’ll need to re-run `./setup.sh`)
+12. Update `changelog.md` with the latest version’s release notes
+13. `git add .`
+14. `git commit`
+15. `git push origin master`
+16. Released!
 
 ## Open source licensing info
 1. [TERMS](TERMS.md)


### PR DESCRIPTION
Update the readme with instructions of releasing the latest iteration at the end of a sprint

## Additions

- Release instructions to the readme

## Removals

- We're not using semver right now, so I took that line out of the changelog

## Changes

- Updated the changelog for the 0.52 release (and to break long lines)

## Testing

Does everything make sense?

## Review

- @anselmbradford 

## Notes

- Right now the release instructions are just the steps I took to get 0.52 out there. There are probably a million improvements we could make to the process as we go on.