### PR TITLE
Fixed double underline on log in link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Unused `block` styles.
 
 ### Fixed
-- Nothing.
+- Fixed double underline on log in link.
 
 
 ## [v0.52](https://cfpb.github.io/complaint-intake/versions/0.52/)

--- a/src/v0/form/css/complain.css
+++ b/src/v0/form/css/complain.css
@@ -2264,3 +2264,7 @@ a.annotation-button:hover,
 	padding-left: 24px;
 	font-family: "Avenir Next Medium", Arial, sans-serif
 }
+
+#log-in-link {
+    text-decoration: none;
+}


### PR DESCRIPTION
## Changes

- Added CSS rule to remove double underline on log in link on step 1.

## Testing

- `gulp build` step 1 log in link should not have a double-underline.

## Review

- @niqjohnson 

## Screenshots

<img width="372" alt="screen shot 2016-06-14 at 3 04 59 pm" src="https://cloud.githubusercontent.com/assets/704760/16055978/6b4602a0-3241-11e6-8917-f9c03e0cbc7b.png">
