### PR TITLE
Shows POC by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Nothing.
 
 ### Changed
-- Nothing.
+- Address and phone number for additional point of contact visible by default.
 
 ### Deprecated
 - Nothing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Nothing.
 
 ### Changed
-- Address and phone number for additional point of contact visible by default.
+- Full name and email for additional point of contact visible by default.
 
 ### Deprecated
 - Nothing.

--- a/src/v0/form/js/main.js
+++ b/src/v0/form/js/main.js
@@ -725,9 +725,9 @@ $('fieldset.point-of-contact').hide();
 $('#consumer1-identity').hide();
 $('#addcon-phone-number').hide();
 $('#addcon-email-helper').hide();
-$('#poc-email-helper').hide();
-$('#poc-phone-number').hide();
-$('#poc-disclosure').hide();
+// $('#poc-email-helper').hide();
+// $('#poc-phone-number').hide();
+// $('#poc-disclosure').hide();
 
 
 
@@ -789,6 +789,7 @@ $('#poc-disclosure').hide();
         }
     });
 
+    /*
     $('#cr-add-poc-full').change(function(){
         if($('#cr-add-poc-full').is(':checked')){
         $('#poc-phone-number').slideDown(400);
@@ -804,6 +805,7 @@ $('#poc-disclosure').hide();
 
         }
     });
+    */
 
   $('.DAMN').on('click', function(){
   		alert('clicked!');
@@ -814,7 +816,6 @@ $('#poc-disclosure').hide();
   		$('.wrapper-container').removeClass('annoslide');
   });
 
-
   $('#annotations-toggle.closed').on('click', function(){
   		$('#annotations-list').slideDown();
   		$('#annotations-toggle a').text('Close annotations');
@@ -824,9 +825,6 @@ $('#poc-disclosure').hide();
   });
 
 $('.cr-military-status').slideUp();
-
-
-
     // error handling without adding a #error-elm
     $('.error-panel a').click(function(){
       $($(this).attr('href')).focus();

--- a/src/v0/form/js/main.js
+++ b/src/v0/form/js/main.js
@@ -725,8 +725,8 @@ $('fieldset.point-of-contact').hide();
 $('#consumer1-identity').hide();
 $('#addcon-phone-number').hide();
 $('#addcon-email-helper').hide();
-// $('#poc-email-helper').hide();
-// $('#poc-phone-number').hide();
+$('#poc-email-helper').hide();
+$('#poc-phone-number').hide();
 // $('#poc-disclosure').hide();
 
 
@@ -789,23 +789,21 @@ $('#addcon-email-helper').hide();
         }
     });
 
-    /*
     $('#cr-add-poc-full').change(function(){
         if($('#cr-add-poc-full').is(':checked')){
         $('#poc-phone-number').slideDown(400);
 		$('#poc-email-helper').slideDown();
-		$('#poc-disclosure').slideDown();
-        $('.poc-email-address').removeClass('cr-question-last');
+		//$('#poc-disclosure').slideDown();
+    $('.poc-email-address').removeClass('cr-question-last');
 
         }else{
         $('#poc-phone-number').slideUp(400);
-        $('#poc-disclosure').slideUp();
+        // $('#poc-disclosure').slideUp();
 		$('#poc-email-helper').hide();
         $('.poc-email-address').addClass('cr-question-last');
 
         }
     });
-    */
 
   $('.DAMN').on('click', function(){
   		alert('clicked!');


### PR DESCRIPTION
## Changes

- Name and email for additional point of contact visible by default.

## Testing

- `gulp build`
- Visit /dist/your-information.html
- Check "Yes" in "Additional point of contact"
- The full name and email should be showing by default without requiring checking "Allow this person full access to this complaint in addition to status updates."
- Checking "Allow this person full access to this complaint in addition to status updates." shows/hides the full address.

## Review

- @niqjohnson
- @higs4281 

## Screenshots

<img width="863" alt="screen shot 2016-06-15 at 11 13 40 am" src="https://cloud.githubusercontent.com/assets/704760/16085506/4880233c-32ea-11e6-8ae9-e310df2a158d.png">

<img width="865" alt="screen shot 2016-06-15 at 11 13 32 am" src="https://cloud.githubusercontent.com/assets/704760/16085505/4879faca-32ea-11e6-84de-c745b915e1a7.png">
