### PR TITLE
Removed optional text from company information and contact info steps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Removed
 - Diagonal striping background images.
+- Optional text from company information and contact info steps.
 
 ### Fixed
 - Nothing.

--- a/src/company-information.html
+++ b/src/company-information.html
@@ -618,8 +618,7 @@ ADDITIONAL COMPANY
             <fieldset class="cr-fieldset">
                 <div class="span3 cr-label">
                     <label>
-                        Does this complaint involve an additional company? <small class="inline">(Optional)</small>
-                        <div class='is-required'>Optional</div>
+                        Does this complaint involve an additional company?
                     </label>
 
                 </div>

--- a/src/your-information.html
+++ b/src/your-information.html
@@ -521,10 +521,10 @@ ADDITIONAL CONSUMER. SAME AS ABOVE CONTENT, MOSTLY
         <fieldset class="cr-fieldset">
             <div class="span3 cr-label">
                 <label>
-                    <span id="add-consumer-label">Does this complaint involve an additional account holder, card-holder or co-signer?</span> <small class="inline">(Optional)</small>
-                    <div class='is-required'>Optional</div>
+                    <span id="add-consumer-label">
+                        Does this complaint involve an additional account holder, card-holder or co-signer?
+                    </span>
                 </label>
-
             </div>
 
             <div class="span9 cr-answer cr-radios cr-behalf cr-add-con prodselect">
@@ -706,10 +706,8 @@ POINT OF CONTACT
             <fieldset class="cr-fieldset point-of-contact-question">
                 <div class="span3 cr-label">
                     <label>
-                        Should we send status updates to anyone else about this complaint? <small class="inline">(Optional)</small>
-                        <div class='is-required'>Optional</div>
+                        Should we send status updates to anyone else about this complaint?
                     </label>
-
                 </div>
 
                 <div class="span9 cr-answer cr-radios cr-behalf cr-add-poc prodselect">


### PR DESCRIPTION
## Removals

- Optional text from company information and contact info steps.

## Testing

- `gulp build`
- Optional tags should be removed from the following sections:
  - Additional company (step 4)
  - Additional consumer (step 5)
  - Additional point of contact (step 5)

## Review

- @niqjohnson 
- @higs4281 

## Screenshots

<img width="901" alt="screen shot 2016-06-15 at 3 06 00 pm" src="https://cloud.githubusercontent.com/assets/704760/16093711/0a4d5f5a-330b-11e6-9efb-9d8e7d634ef5.png">

<img width="925" alt="screen shot 2016-06-15 at 3 05 54 pm" src="https://cloud.githubusercontent.com/assets/704760/16093712/0a5436ea-330b-11e6-9b45-8c7a3cc8cddb.png">