### PR TITLE
Show "what school" input when selecting private student loan on step 1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Nothing.
 
 ### Fixed
-- Nothing.
+- Show "what school" input when selecting private student loan on step 1.
 
 
 ## [0.7.0](https://cfpb.github.io/complaint-intake/versions/0.7.0/)

--- a/src/v0/form/js/main.js
+++ b/src/v0/form/js/main.js
@@ -333,7 +333,7 @@ $('#mortgage_servicer_questions').hide();
         }
         if ( $(this).parent().attr('id') == 'federal-student-loan'){
         $('#student_questions').slideDown().show();
-        } else if ( $(this).parent().attr('id') == 'non-federal-student-loan'){
+        } else if ( $(this).parent().attr('id') == 'private-student-loan'){
         $('#student_questions').slideDown().show();
         } else {
          $('#student_questions').slideUp();


### PR DESCRIPTION
## Changes

- Show "what school" input when selecting private student loan on step 1.

## Testing

- `gulp clean && gulp build`
- In step 1, select "Student loan" > "Private student loan"
- Should show "What school were you attending when you received the loan?"

## Review

- @niqjohnson 

## Screenshots

![screen shot 2016-06-23 at 4 11 14 pm](https://cloud.githubusercontent.com/assets/704760/16318496/7d125f38-395d-11e6-91f6-7912f1ec64ae.png)