### PR TITLE
General cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Nothing.
 
 ### Changed
-- Nothing.
+- Updated autoprefixer to 3.1.0.
 
 ### Deprecated
 - Nothing.

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -15,7 +15,11 @@ gulp.task( 'styles:modern', function() {
     .pipe( plugins.less( configStyles.settings ) )
     .on( 'error', handleErrors )
     .pipe( plugins.autoprefixer( {
-      browsers: [ 'last 2 version' ]
+      browsers: [ 'last 2 version',
+                  'not ie <= 8',
+                  'android 4',
+                  'BlackBerry 7',
+                  'BlackBerry 10' ]
     } ) )
     .pipe( plugins.header( configBanner, { pkg: configPkg } ) )
     .pipe( plugins.rename( {
@@ -33,7 +37,7 @@ gulp.task( 'styles:ie', function() {
     .pipe( plugins.less( configStyles.settings ) )
     .on( 'error', handleErrors )
     .pipe( plugins.autoprefixer( {
-      browsers: [ 'IE 7', 'IE 8' ]
+      browsers: [ 'ie 7-8' ]
     } ) )
     .pipe( mqr( {
       width: '75em'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "complaint-intake",
-  "version": "0.1.0",
+  "version": "0.8.0",
   "description": "Improving the forms used by consumers to submit complaints about the financial marketplace.",
   "homepage": "https://github.com/cfpb/complaint-intake/",
   "author": {
@@ -26,7 +26,6 @@
     "cf-grid": "^3.1.2",
     "cf-typography": "^3.0.5",
     "cf-core": "^3.2.2",
-    "cf-core": "^3.2.2",
     "cf-layout": "^3.2.0",
     "html5shiv": "3.7.3"
   },
@@ -35,7 +34,7 @@
     "del": "1.2.0",
     "fs": "0.0.2",
     "gulp": "3.9.1",
-    "gulp-autoprefixer": "2.3.1",
+    "gulp-autoprefixer": "3.1.0",
     "gulp-changed": "1.2.1",
     "gulp-concat": "2.6.0",
     "gulp-webpack": "1.5.0",

--- a/src/company-information.html
+++ b/src/company-information.html
@@ -1414,10 +1414,6 @@ MOBILE WALLET OPTIONS.
 
 </script>
 
-<!-- /.primary -->
-</div> <!-- select product -->
-
-
 </section>
 
 <div class="row cr-continue">


### PR DESCRIPTION
I noticed the pagination was ending up full window width on step 3. This fixes that.

## Changes

- Removes incorrectly nested div.
- Updates version in package.json.
- Updates autoprefixer version and associated syntax.

## Testing

- `gulp clean && gulp build` should work.
- /company-information.html pagination should not be full width.

## Review

- @niqjohnson 
