### PR TITLE
Fix - erroneously displaying "how to contact"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - cursor.png and associated styles.
 
 ### Fixed
-- Nothing.
+- Fix issue where "how to contact" in additional company erroneously displays.
 
 
 ## [0.8.0](https://cfpb.github.io/complaint-intake/versions/0.8.0/)

--- a/src/v0/form/js/main.js
+++ b/src/v0/form/js/main.js
@@ -623,39 +623,39 @@ $( '.add-company-yes' ).on( 'change', function(){
 
         switch ( product ) {
           case 'mortgage':
-            $('#identify-mortgage-company').appendTo('#additional-company-div');
+            $('#identify-mortgage-company').appendTo('#additional-company-div').hide();
           break;
 
           case 'student_loan':
-            $('#identify-student-loan-company').appendTo('#additional-company-div');
+            $('#identify-student-loan-company').appendTo('#additional-company-div').hide();
           break;
 
           case 'vehicle_loan':
-            $('#identify-vehicle-loan-company').appendTo('#additional-company-div');
+            $('#identify-vehicle-loan-company').appendTo('#additional-company-div').hide();
           break;
 
           case 'consumer_loan':
-            $('#identify-storefront-services-company').appendTo('#additional-company-div');
+            $('#identify-storefront-services-company').appendTo('#additional-company-div').hide();
           break;
 
           case 'card':
-            $('#identify-most-prepaids-company').appendTo('#additional-company-div');
+            $('#identify-most-prepaids-company').appendTo('#additional-company-div').hide();
           break;
 
           case 'checking':
-            $('#identify-checking-savings-company').appendTo('#additional-company-div');
+            $('#identify-checking-savings-company').appendTo('#additional-company-div').hide();
           break;
 
           case 'money_trans':
-            $('#identify-money-transfer-company').appendTo('#additional-company-div');
+            $('#identify-money-transfer-company').appendTo('#additional-company-div').hide();
           break;
 
           case 'credit_reporting':
-            $('#identify-credit-reporting-company').appendTo('#additional-company-div');
+            $('#identify-credit-reporting-company').appendTo('#additional-company-div').hide();
           break;
 
           case 'debt':
-            $('#identify-debt-collection-company').appendTo('#additional-company-div');
+            $('#identify-debt-collection-company').appendTo('#additional-company-div').hide();
           break;
         }
         _additionalCompanyProduct = product;


### PR DESCRIPTION
There is a bug where if you enter a non-existent company, the "How should this company identify you" was showing before the checkbox in additional company was checked as noted by @kurzn

## Changes

- Fix - erroneously displaying "how to contact" on additional company.

## Testing

- `gulp clean && gulp build`
- /dist/company-information.html
- Fill in non-existing company at the top.
- Click "Yes" for additional company.
- Select type of product from drop-down.
- "How should this company identify you?" section should not show till "This company should also receive and respond to this complaint" is checked.

## Review

- @niqjohnson 
