### PR TITLE
Added prefixes to address fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 - Moves inline JS to modules.
+- Added prefixes to address fields.
 
 ### Deprecated
 - Nothing.

--- a/src/company-information.html
+++ b/src/company-information.html
@@ -197,9 +197,13 @@ COMPANY-1
 
         <div class="row cr-question">
 
-            <h3>Currently, this company isn’t signed up to receive complaints through our system</h3>
+            <h3>
+                Currently, this company isn’t signed up to receive complaints through our system
+            </h3>
 
-            <p>We are continuously adding new companies to our system. However, the company you searched for has not yet signed up to receive complaints. Please provide as much information as possible so that we can contact the company and send them your complaint.</p><p>If we find that another government agency would be better able to assist, we will forward your complaint and let you know.</p>
+            <p>We are continuously adding new companies to our system. However, the company you searched for has not yet signed up to receive complaints. Please provide as much information as possible so that we can contact the company and send them your complaint.</p>
+
+            <p>If we find that another government agency would be better able to assist, we will forward your complaint and let you know.</p>
 
             <div class="row cr-question">
                 <div class="span3 cr-label cr-question-with-checkbox">
@@ -212,7 +216,9 @@ COMPANY-1
                 </div>
             </div>
 
-            <div id="address0" class="row cr-question address-template">
+            <div id="address0"
+                 class="row cr-question address-template"
+                 data-label="Company address">
                 <!-- Handlebars will add address template here. -->
             </div>
 
@@ -331,7 +337,9 @@ COMPANY-2
                 </div>
             </div>
 
-            <div id="address1" class="row cr-question address-template">
+            <div id="address1"
+                 class="row cr-question address-template"
+                 data-label="Company address">
                 <!-- Handlebars will add address template here. -->
             </div>
 
@@ -515,7 +523,9 @@ ADDITIONAL COMPANY
                 </div>
             </div>
 
-            <div id="address2" class="row cr-question address-template">
+            <div id="address2"
+                 class="row cr-question address-template"
+                 data-label="Company address">
                 <!-- Handlebars will add address template here. -->
             </div>
 
@@ -1136,19 +1146,25 @@ MOBILE WALLET OPTIONS.
 <div id="fieldset_repository">
 
     <fieldset class="cr-fieldset identify-options billing-address in-repository">
-        <div id="address3" class="row cr-question address-template">
+        <div id="address3"
+             class="row cr-question address-template"
+             data-label="Billing address">
             <!-- Handlebars will add address template here. -->
         </div>
     </fieldset>
 
     <fieldset class="cr-fieldset identify-options residence-address in-repository">
-        <div id="address4" class="row cr-question address-template">
+        <div id="address4"
+             class="row cr-question address-template"
+             data-label="Residence address">
             <!-- Handlebars will add address template here. -->
         </div>
     </fieldset>
 
     <fieldset class="cr-fieldset identify-options address-dob in-repository">
-        <div id="address5" class="row cr-question address-template">
+        <div id="address5"
+             class="row cr-question address-template"
+             data-label="Residence address">
             <!-- Handlebars will add address template here. -->
         </div>
     </fieldset>

--- a/src/static/js/modules/international-addresses.js
+++ b/src/static/js/modules/international-addresses.js
@@ -35,7 +35,8 @@ function init() {
 }
 
 function _initAddress( addressDom, id ) {
-  addressDom.innerHTML = addressHandlebars( { id: id } );
+  var label = addressDom.getAttribute( 'data-label' );
+  addressDom.innerHTML = addressHandlebars( { id: id, label: label } );
   _countryDropdownDom = addressDom.querySelector( '#address-country-' + id );
   _addressMap[_countryDropdownDom.id] = addressDom;
   _countryDropdownDom.addEventListener( 'change', _countryChanged );
@@ -43,8 +44,9 @@ function _initAddress( addressDom, id ) {
 
 function _countryChanged( evt ) {
   var tmp = evt.target.id.split( '-' );
+  var label = evt.target.getAttribute( 'data-label' );
   var id = tmp[tmp.length-1];
-  var opts = { id: id };
+  var opts = { id: id, label: label };
   opts[ 'country' + evt.target.value ] = true;
   // 100 is the value code for the USA.
   if ( evt.target.value !== '100' ) {

--- a/src/static/tmpl/address.handlebars
+++ b/src/static/tmpl/address.handlebars
@@ -1,11 +1,11 @@
 <div class="row cr-question">
     <div class="span3 cr-label cr-question-left">
         <label for="address-country-{{id}}">
-            Country
+            {{label}} country
             <small class="inline"></small>
         </label>
 
-        <select id="address-country-{{id}}" class="filled">
+        <select id="address-country-{{id}}" class="filled" data-label="{{label}}">
             {{#if country100 }}
                 <option label="United States" value="100" selected="selected">United States</option>
             {{else}}
@@ -43,187 +43,187 @@
             {{/if}}
 
             {{#if country2852 }}
-                <option label="Antigua and Barbuda" value="2852">Antigua and Barbuda</option>
+                <option label="Antigua and Barbuda" value="2852" selected="selected">Antigua and Barbuda</option>
             {{else}}
                 <option label="Antigua and Barbuda" value="2852">Antigua and Barbuda</option>
             {{/if}}
 
             {{#if country1009 }}
-                <option label="Argentina" value="1009">Argentina</option>
+                <option label="Argentina" value="1009" selected="selected">Argentina</option>
             {{else}}
                 <option label="Argentina" value="1009">Argentina</option>
             {{/if}}
 
             {{#if country2853 }}
-                <option label="Armenia" value="2853">Armenia</option>
+                <option label="Armenia" value="2853" selected="selected">Armenia</option>
             {{else}}
                 <option label="Armenia" value="2853">Armenia</option>
             {{/if}}
 
             {{#if country1010 }}
-                <option label="Australia" value="1010">Australia</option>
+                <option label="Australia" value="1010" selected="selected">Australia</option>
             {{else}}
                 <option label="Australia" value="1010">Australia</option>
             {{/if}}
 
             {{#if country1011 }}
-                <option label="Austria" value="1011">Austria</option>
+                <option label="Austria" value="1011" selected="selected">Austria</option>
             {{else}}
                 <option label="Austria" value="1011">Austria</option>
             {{/if}}
 
             {{#if country1012 }}
-                <option label="Azerbaijan" value="1012">Azerbaijan</option>
+                <option label="Azerbaijan" value="1012" selected="selected">Azerbaijan</option>
             {{else}}
                 <option label="Azerbaijan" value="1012">Azerbaijan</option>
             {{/if}}
 
             {{#if country2854 }}
-                <option label="Bahamas" value="2854">Bahamas</option>
+                <option label="Bahamas" value="2854" selected="selected">Bahamas</option>
             {{else}}
                 <option label="Bahamas" value="2854">Bahamas</option>
             {{/if}}
 
             {{#if country2855 }}
-                <option label="Bahrain" value="2855">Bahrain</option>
+                <option label="Bahrain" value="2855" selected="selected">Bahrain</option>
             {{else}}
                 <option label="Bahrain" value="2855">Bahrain</option>
             {{/if}}
 
             {{#if country2856 }}
-                <option label="Bangladesh" value="2856">Bangladesh</option>
+                <option label="Bangladesh" value="2856" selected="selected">Bangladesh</option>
             {{else}}
                 <option label="Bangladesh" value="2856">Bangladesh</option>
             {{/if}}
 
             {{#if country2857 }}
-                <option label="Barbados" value="2857">Barbados</option>
+                <option label="Barbados" value="2857" selected="selected">Barbados</option>
             {{else}}
                 <option label="Barbados" value="2857">Barbados</option>
             {{/if}}
 
             {{#if country1013 }}
-                <option label="Belarus" value="1013">Belarus</option>
+                <option label="Belarus" value="1013" selected="selected">Belarus</option>
             {{else}}
                 <option label="Belarus" value="1013">Belarus</option>
             {{/if}}
 
             {{#if country1014 }}
-                <option label="Belgium" value="1014">Belgium</option>
+                <option label="Belgium" value="1014" selected="selected">Belgium</option>
             {{else}}
                 <option label="Belgium" value="1014">Belgium</option>
             {{/if}}
 
             {{#if country1015 }}
-                <option label="Belize" value="1015">Belize</option>
+                <option label="Belize" value="1015" selected="selected">Belize</option>
             {{else}}
                 <option label="Belize" value="1015">Belize</option>
             {{/if}}
 
             {{#if country2858 }}
-                <option label="Benin" value="2858">Benin</option>
+                <option label="Benin" value="2858" selected="selected">Benin</option>
             {{else}}
                 <option label="Benin" value="2858">Benin</option>
             {{/if}}
 
             {{#if country2859 }}
-                <option label="Bhutan" value="2859">Bhutan</option>
+                <option label="Bhutan" value="2859" selected="selected">Bhutan</option>
             {{else}}
                 <option label="Bhutan" value="2859">Bhutan</option>
             {{/if}}
 
             {{#if country1016 }}
-                <option label="Bolivia" value="1016">Bolivia</option>
+                <option label="Bolivia" value="1016" selected="selected">Bolivia</option>
             {{else}}
                 <option label="Bolivia" value="1016">Bolivia</option>
             {{/if}}
 
             {{#if country1017 }}
-                <option label="Bosnia and Herzegovina" value="1017">Bosnia and Herzegovina</option>
+                <option label="Bosnia and Herzegovina" value="1017" selected="selected">Bosnia and Herzegovina</option>
             {{else}}
                 <option label="Bosnia and Herzegovina" value="1017">Bosnia and Herzegovina</option>
             {{/if}}
 
             {{#if country2860 }}
-                <option label="Botswana" value="2860">Botswana</option>
+                <option label="Botswana" value="2860" selected="selected">Botswana</option>
             {{else}}
                 <option label="Botswana" value="2860">Botswana</option>
             {{/if}}
 
             {{#if country1018 }}
-                <option label="Brazil" value="1018">Brazil</option>
+                <option label="Brazil" value="1018" selected="selected">Brazil</option>
             {{else}}
                 <option label="Brazil" value="1018">Brazil</option>
             {{/if}}
 
             {{#if country1019 }}
-                <option label="Brunei Darussalam" value="1019">Brunei Darussalam</option>
+                <option label="Brunei Darussalam" value="1019" selected="selected">Brunei Darussalam</option>
             {{else}}
                 <option label="Brunei Darussalam" value="1019">Brunei Darussalam</option>
             {{/if}}
 
             {{#if country1020 }}
-                <option label="Bulgaria" value="1020">Bulgaria</option>
+                <option label="Bulgaria" value="1020" selected="selected">Bulgaria</option>
             {{else}}
                 <option label="Bulgaria" value="1020">Bulgaria</option>
             {{/if}}
 
             {{#if country2861 }}
-                <option label="Burkina Faso" value="2861">Burkina Faso</option>
+                <option label="Burkina Faso" value="2861" selected="selected">Burkina Faso</option>
             {{else}}
                 <option label="Burkina Faso" value="2861">Burkina Faso</option>
             {{/if}}
 
             {{#if country2862 }}
-                <option label="Burma" value="2862">Burma</option>
+                <option label="Burma" value="2862" selected="selected">Burma</option>
             {{else}}
                 <option label="Burma" value="2862">Burma</option>
             {{/if}}
 
             {{#if country2863 }}
-                <option label="Burundi" value="2863">Burundi</option>
+                <option label="Burundi" value="2863" selected="selected">Burundi</option>
             {{else}}
                 <option label="Burundi" value="2863">Burundi</option>
             {{/if}}
 
             {{#if country2864 }}
-                <option label="Cambodia" value="2864">Cambodia</option>
+                <option label="Cambodia" value="2864" selected="selected">Cambodia</option>
             {{else}}
                 <option label="Cambodia" value="2864">Cambodia</option>
             {{/if}}
 
             {{#if country2865 }}
-                <option label="Cameroon" value="2865">Cameroon</option>
+                <option label="Cameroon" value="2865" selected="selected">Cameroon</option>
             {{else}}
                 <option label="Cameroon" value="2865">Cameroon</option>
             {{/if}}
 
             {{#if country1021 }}
-                <option label="Canada" value="1021">Canada</option>
+                <option label="Canada" value="1021" selected="selected">Canada</option>
             {{else}}
                 <option label="Canada" value="1021">Canada</option>
             {{/if}}
 
             {{#if country2866 }}
-                <option label="Cape Verde" value="2866">Cape Verde</option>
+                <option label="Cape Verde" value="2866" selected="selected">Cape Verde</option>
             {{else}}
                 <option label="Cape Verde" value="2866">Cape Verde</option>
             {{/if}}
 
             {{#if country2867 }}
-                <option label="Cayman Islands" value="2867">Cayman Islands</option>
+                <option label="Cayman Islands" value="2867" selected="selected">Cayman Islands</option>
             {{else}}
                 <option label="Cayman Islands" value="2867">Cayman Islands</option>
             {{/if}}
 
             {{#if country2868 }}
-                <option label="Central African Republic" value="2868">Central African Republic</option>
+                <option label="Central African Republic" value="2868" selected="selected">Central African Republic</option>
             {{else}}
                 <option label="Central African Republic" value="2868">Central African Republic</option>
             {{/if}}
 
             {{#if country2869 }}
-                <option label="Chad" value="2869">Chad</option>
+                <option label="Chad" value="2869" selected="selected">Chad</option>
             {{else}}
                 <option label="Chad" value="2869">Chad</option>
             {{/if}}
@@ -396,7 +396,7 @@
 <div class="row cr-question">
     <div class="span3 cr-label cr-question-left">
         <label for="address-line1-{{id}}">
-            Address line 1
+            {{label}} line 1
         </label>
         <input type="text"
                name="address-line1-{{id}}"
@@ -406,7 +406,7 @@
 <div class="row cr-question">
     <div class="span3 cr-label cr-question-left">
         <label for="address-line2-{{id}}">
-            Address line 2 <small class="inline">(Optional)</small>
+            {{label}} line 2 <small class="inline">(Optional)</small>
             <div class='is-required'>Answer Required</div>
         </label>
 
@@ -419,7 +419,7 @@
 <div class="row cr-question">
     <div class="span3 cr-label cr-question-left">
         <label for="address-line3-{{id}}">
-            Address line 3 <small class="inline">(Optional)</small>
+            {{label}} address line 3 <small class="inline">(Optional)</small>
             <div class='is-required'>Answer Required</div>
         </label>
 

--- a/src/your-information.html
+++ b/src/your-information.html
@@ -172,7 +172,7 @@
                 <!-- end .error-panel -->
                 <h3 id="primary-consumer-section">Primary consumer</h3>
                 <p>Tell us about the person who is having this issue.</p>
-                <!--            <p>The person who is having this issue</p> -->
+                <!-- <p>The person who is having this issue</p> -->
 
                 <fieldset id="consumer1-identity" class="cr-fieldset">
                     <!-- question -->
@@ -270,7 +270,9 @@
             </fieldset>
 
             <fieldset id="primary-consumer-phone-and-zip" class="cr-fieldset">
-                <div id="address0" class="row cr-question address-template">
+                <div id="address0"
+                     class="row cr-question address-template"
+                     data-label="Residence address">
                     <!-- Handlebars will add address template here. -->
                 </div>
 
@@ -569,7 +571,9 @@ ADDITIONAL CONSUMER. SAME AS ABOVE CONTENT, MOSTLY
 
     <div id="addcon-phone-number" class="row cr-question cr-question-last">
 
-        <div id="address1" class="row cr-question address-template">
+        <div id="address1"
+             class="row cr-question address-template"
+             data-label="Residence address">
             <!-- Handlebars will add address template here. -->
         </div>
         <div class="row cr-question cr-question-last">
@@ -803,7 +807,9 @@ POINT OF CONTACT
 
         <div id="poc-phone-number" class="row cr-question cr-question-last">
 
-            <div id="address2" class="row cr-question address-template">
+            <div id="address2"
+                 class="row cr-question address-template"
+                 data-label="Residence address">
                 <!-- Handlebars will add address template here. -->
             </div>
 


### PR DESCRIPTION
## Changes

- Added prefixes to address fields.

## Testing

- `gulp clean && gulp build`
- Visit /company-information.html and /your-information.html
- View any address field and see the country, address line 1, and address line 2 is prefixed with the type of address.

## Review

- @niqjohnson 

## Screenshots

![screen shot 2016-06-29 at 11 58 23 am](https://cloud.githubusercontent.com/assets/704760/16459621/716abc28-3df1-11e6-83cb-1ce822a7cfe2.png)

![screen shot 2016-06-29 at 11 58 48 am](https://cloud.githubusercontent.com/assets/704760/16459620/7169a9aa-3df1-11e6-97a6-1c74d3c94f02.png)

![screen shot 2016-06-29 at 11 58 13 am](https://cloud.githubusercontent.com/assets/704760/16459623/716e7f84-3df1-11e6-8575-8707336c05d7.png)

![screen shot 2016-06-29 at 11 58 44 am](https://cloud.githubusercontent.com/assets/704760/16459622/716d894e-3df1-11e6-85a3-7011984f3c11.png)
