### PR TITLE
72 affiliations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Added prefixes to address fields.
 - Formatted Social Security Number input field as three fields.
 - Changes drop-down text for your information "This person is..." drop-down.
+- Moves affiliations section to primary consumer section.
+- Makes affiliations checkboxes show current status sections concurrently.
+- Move checkboxes onto its own row.
 
 ### Deprecated
 - Nothing.

--- a/src/static/js/modules/step-your-information.js
+++ b/src/static/js/modules/step-your-information.js
@@ -11,14 +11,24 @@ function init() {
 
    // Show/hide military status
   $( '.cr-servicemember input' ).on( 'change', function(){
-    if ( $( '.cr-need-servicemember-info' ).is( ':checked' ) ) {
-      $( '.cr-servicemember-info, .cr-military-status' ).slideDown( 400 );
+    if ( $( '#cr-military-spouse' ).is( ':checked' ) ) {
+      $( '#servicemember-details' ).slideDown( 400 );
+      $( '.cr-servicemember-info' ).slideUp( 300 );
       $( '.cr-military-status hr' ).hide();
-    } else if ( $( '.cr-need-military-status' ).is( ':checked' ) ) {
-      $( '.cr-military-status' ).slideDown( 400 );
+    } else {
+      $( '#servicemember-details' ).slideUp( 400 );
+    }
+
+    if ( $( '#cr-military-status' ).is( ':checked' ) ) {
+      $( '#servicemember-details1' ).slideDown( 400 );
       $( '.cr-servicemember-info' ).slideUp( 300 );
       $( '.cr-military-status hr' ).show();
     } else {
+      $( '#servicemember-details1' ).slideUp( 400 );
+    }
+
+    if ( !$( '#cr-military-status' ).is( ':checked' ) &&
+         !$( '#cr-military-spouse' ).is( ':checked' ) ) {
       $( '.cr-servicemember-info, .cr-military-status' ).slideUp( 300 );
     }
   } );
@@ -126,13 +136,14 @@ function init() {
   $( '#addcon-email-helper' ).hide();
   $( '#poc-email-helper' ).hide();
   $( '#poc-phone-number' ).hide();
+  $( '#poc-allow-access-disclosure' ).hide();
+  $( '#add-consumer-allow-access-disclosure' ).hide();
   // $( '#poc-disclosure' ).hide();
 
   $( '#ans-poc-other-who' ).slideUp();
     $( '#point-of-contact-identity' ).on( 'change', function(){
     var poctype = $(this).val();
     $( '#ans-poc-other-who' ).slideDown();
-    $( '#ans-poc-other-who-spacer' ).slideUp();
 
     /* alert(poctype); */
 
@@ -146,8 +157,7 @@ function init() {
         break;
 
       case 'friend':
-        $( '#cr-poc-other-who-label' ).text( 'Type of friend' );
-        $( '#ans-poc-other-who' ).hide();
+        $( '#ans-poc-other-who' ).slideUp();
         break;
 
       case 'attorney':
@@ -180,11 +190,13 @@ function init() {
       $( '#addcon-optional-status' ).text( '' );
       $( '#addcon-email-helper' ).slideDown();
       $( '#addcon-phone-number' ).slideDown();
+      $( '#add-consumer-allow-access-disclosure' ).slideDown();
       $( '.additional-consumer-email' ).removeClass( 'cr-question-last' );
     } else {
       $( '#addcon-optional-status' ).text( '(Optional)' );
       $( '#addcon-email-helper' ).slideUp();
       $( '#addcon-phone-number' ).slideUp();
+      $( '#add-consumer-allow-access-disclosure' ).slideUp();
       $( '.additional-consumer-email' ).addClass( 'cr-question-last' );
     }
   } );
@@ -193,11 +205,11 @@ function init() {
     if ( $( '#cr-add-poc-full' ).is( ':checked' ) ) {
       $( '#poc-phone-number' ).slideDown( 400 );
       $( '#poc-email-helper' ).slideDown();
-      //$( '#poc-disclosure' ).slideDown();
+      $( '#poc-allow-access-disclosure' ).slideDown();
       $( '.poc-email-address' ).removeClass( 'cr-question-last' );
     } else {
       $( '#poc-phone-number' ).slideUp( 400 );
-      // $( '#poc-disclosure' ).slideUp();
+      $( '#poc-allow-access-disclosure' ).slideUp();
       $( '#poc-email-helper' ).hide();
       $( '.poc-email-address' ).addClass( 'cr-question-last' );
     }

--- a/src/v0/form/css/complain.css
+++ b/src/v0/form/css/complain.css
@@ -444,11 +444,15 @@ cruxform .cr-question-left input.accountinput {
 }
 
 .cruxform .cr-question-right p {
-    margin: 0px 0px 0 18px;
+    margin: 0 0 0 18px;
 }
 
 .cruxform .cr-question-left p {
-    margin: 44px 0px 4px 18px;
+    margin: 44px 0 4px 18px;
+}
+
+.borrower-email .cr-question-left p {
+    margin-top: 0;
 }
 
 .cruxform .cr-question-left.identify-debt-collection-company-phone {
@@ -476,13 +480,18 @@ fieldset {
     margin:0px;
 }
 
-.cr-label label, .cr-label legend {
+.cr-label label,
+.cr-label legend {
     width: 100%;
     font-family: "Avenir Next Medium", Arial, sans-serif;
     font-weight: 400;
     font-size: 16px;
     padding: 16px 8px 3px 18px;
     text-align: left;
+}
+
+.cr-label .label-subtext {
+    padding-left: 18px;
 }
 
 .cr-label.cr-question-col {
@@ -1837,10 +1846,6 @@ button.secondary {
     background: #75787B;
 }
 
-#no-email-address-checkbox {
-    text-indent: -18px;
-}
-
 #review-sections {
     padding-top: 16px;
     margin-bottom: 56px;
@@ -2036,12 +2041,13 @@ ul#welcome-list li {
     padding-top: 20px;
 }
 
-#consumer2-identity .right-helper label,
-.point-of-contact .right-helper label {
+#consumer2-identity .right-helper label {
     text-indent: -16px;
 }
 
-#poc-disclosure p {
+#poc-disclosure p,
+#add-consumer p,
+#addcon-phone-number p {
     margin-left: 20px;
     padding: 8px 0;
 }
@@ -2185,4 +2191,9 @@ a.annotation-button:hover,
     float: left;
     margin-left: 10px;
     margin-top: 5px;
+}
+
+#affiliations {
+    border-top: dotted 1px #ccc;
+    padding-top: 12px;
 }

--- a/src/your-information.html
+++ b/src/your-information.html
@@ -133,7 +133,7 @@
      BEGIN CONTENT
      ============= -->
 
-     <section class="content row cr-content">
+    <section class="content row cr-content">
 
         <div class="span8 cr-primary">
             <!-- .error-panel -->
@@ -189,7 +189,7 @@
                                 <option id="primary-consumer-identity-option2" class="consumer-identity-options" value="#">Additional account holder</option>
                                 <option id="primary-consumer-identity-option3" class="consumer-identity-options" value="#">Joint account holder</option>
                                 <option id="primary-consumer-identity-option4" class="consumer-identity-options" value="#">Additional card holder</option>
-            <!--
+                            <!--
                                 <option id="primary-consumer-identity-option5" class="consumer-identity-options" value="#">Co-Signer</option>
                                 <option id="primary-consumer-identity-option6" class="consumer-identity-options" value="#">Co-borrower</option>
                                 <option id="primary-consumer-identity-option7" class="consumer-identity-options" value="#">Sender</option>
@@ -312,93 +312,308 @@
             <fieldset id="primary-consumer-email" class="cr-fieldset">
 
                 <!-- email address -->
-                <div class="cr-question borrower-email cr-question-last">
-                    <div class="span3 cr-label cr-question-left cr-question-with-checkbox">
+                <div class="cr-question borrower-email">
+                    <div class="span2 cr-label cr-question-left">
                         <label for="con1-email">
                             Email address <!-- <small class="inline">(This is required for official correspondence)</small> -->
                             <div class='is-required'>Answer Required</div>
                         </label>
 
+                        <p>We’ll use this email address to send updates about the status of this complaint. It will also be the username for the account.</p>
+
                         <input type="email"
                                name="cr-email2"
                                id="cr-email2_2356852120719850"
                                class="input-large left">
-                        <p>We’ll use this email address to send updates about the status of this complaint. It will also be the username for the account.</p>
                     </div>
-                    <div class="span2 cr-label cr-question-right right-helper question-checkbox">
-                        <label id="no-email-address-checkbox" class="radio block">
+                </div>
+                <!-- /email  -->
+                <div class="row cr-question cr-question-last">
+                    <div class="span2 cr-label right-helper question-checkbox">
+                        <label id="no-email-address-checkbox">
                             <input type="checkbox" name="no-email" value="no-email" class="cr-no-email checkbox" id="cr-no-email">
                             The primary consumer doesn't have an email address
                         </label>
                     </div>
                 </div>
-                <!-- /email  -->
+    <!--
 
-<!--
+        START CONSUMER DOESN'T HAVE EMAIL ADDRESS
 
-    START CONSUMER DOESN'T HAVE EMAIL ADDRESS
+    -->
 
--->
+    <div id="consumer-info-no-email" class="row cr-question">
 
-<div id="consumer-info-no-email" class="row cr-question">
-
-    <div class="span3 cr-label" style="border-top: dotted 1px #ccc; padding-top: 12px;">
-        <label>
-           How should we contact the primary consumer about the status of this complaint?
-           <div class='is-required'>Required</div>
-       </label>
-   </div>
-
-   <div class="span9 cr-answer cr-radios prodselect cr-behalf">
-    <label class="radio block">
-        <input type="radio" class='identify-account identify-user identification-type phone-number' name="identify-account" value="phone-number">
-        Text message
-    </label>
-
-    <label class="radio block">
-        <input type="radio" class='identify-account identify-user identification-type physical-mail' name="identify-account" value="physical-mail">
-        Mail
-    </label>
-
-    <label class="radio block last">
-        <input type="radio" class='identify-account identify-user identification-type someone-else' name="identify-account" value="someone-else">
-        Someone else will be the point of contact
-    </label>
-</div>
-</div>
-</fieldset>
-<fieldset class="cr-fieldset identify-options physical-mail">
-
-  <div class="row cr-question cr-question-last account-number-row">
-
-      <div class="span3 cr-label">
-          <p style="margin: 1em;">We will mail updates each time your complaint changes status.</p>
-      </div>
-  </div>
-</fieldset>   <!--  /physical mail   -->
-
-<fieldset class="cr-fieldset identify-options phone-number">
-    <div class="row cr-question cr-question-last account-number-row">
-        <div class="span3 cr-label">
-            <p style="margin: 1em;">We will text a message to the number you provided each time your complaint changes in status. Standard messaging rates may apply.</p>
+        <div class="span3 cr-label" style="border-top: dotted 1px #ccc; padding-top: 12px;">
+            <label>
+               How should we contact the primary consumer about the status of this complaint?
+               <div class='is-required'>Required</div>
+            </label>
         </div>
+
+        <div class="span9 cr-answer cr-radios prodselect cr-behalf">
+            <label class="radio block">
+                <input type="radio" class='identify-account identify-user identification-type phone-number' name="identify-account" value="phone-number">
+                Text message
+            </label>
+
+            <label class="radio block">
+                <input type="radio" class='identify-account identify-user identification-type physical-mail' name="identify-account" value="physical-mail">
+                Mail
+            </label>
+
+            <label class="radio block last">
+                <input type="radio" class='identify-account identify-user identification-type someone-else' name="identify-account" value="someone-else">
+                Someone else will be the point of contact
+            </label>
+        </div>
+
+        <fieldset class="cr-fieldset identify-options physical-mail">
+
+            <div class="row cr-question cr-question-last account-number-row">
+
+                <div class="span3 cr-label">
+                    <p style="margin: 1em;">We will mail updates each time your complaint changes status.</p>
+                </div>
+            </div>
+        </fieldset>   <!--  /physical mail   -->
+
+        <fieldset class="cr-fieldset identify-options phone-number">
+            <div class="row cr-question cr-question-last account-number-row">
+                <div class="span3 cr-label">
+                    <p style="margin: 1em;">We will text a message to the number you provided each time your complaint changes in status. Standard messaging rates may apply.</p>
+                </div>
+            </div>
+        </fieldset>
+
+        <fieldset class="cr-fieldset identify-options someone-else">
+
+            <div class="row cr-question cr-question-last account-number-row">
+                <div class="span3 cr-label">
+                   <p style="margin: 1em;">Be sure to include full contact information below.</p>
+                </div>
+
+                <!--
+                    <div class="span2 cr-label cr-question-right right-helper">
+                        <p></p>
+                    </div>
+                -->
+            </div>
+        </fieldset>
+    </div>
+
+    <!--
+    ///////////////
+    AFFILIATIONS
+    ///////////////
+    -->
+    <div class="row cr-question" id="affiliations">
+        <div class="span3 cr-label">
+            <label id="affiliations-section">
+               What affiliations does the primary consumer have? Choose all that apply.
+              <small>(Optional)</small>
+            </label>
+            <p class="label-subtext">We use this information to help identify trends in the marketplace.</p>
+        </div>
+        <fieldset class="span9 cr-answer cr-radios prodselect cr-behalf">
+
+            <!-- question -->
+            <div id="affiliation-question" class="row cr-question">
+                <div id="affiliation-options"
+                     class="span9 cr-answer cr-radios cr-servicemember prodselect">
+
+                    <label class="radio block">
+                        <input type="checkbox"
+                               name="cr-military-status"
+                               value="option1"
+                               class="cr-need-military-status"
+                               id="cr-military-status">
+                        A servicemember or veteran
+                    </label>
+                    <label class="radio block">
+                        <input type="checkbox"
+                               name="cr-military-status2"
+                               value="option2"
+                               class="cr-need-servicemember-info"
+                               id="cr-military-spouse">
+                        The spouse or dependent of a servicemember or veteran
+                    </label>
+                    <label class="radio block">
+                        <input type="checkbox"
+                               name="cr-student"
+                               value="option3"
+                               class="cr-need-over-62">
+                        A current student
+                        <br/><small>Includes any college or university degree program</small>
+                    </label>
+                    <label class="radio block">
+                        <input type="checkbox" name="cr-justice-involved" value="option3" class="cr-need-over-62">
+                        A person with a disability
+                    </label>
+                </div>
+            </div>
+            <!-- /question -->
+        </fieldset>
+        <fieldset id="servicemember-details1"
+                  class="cr-fieldset affiliation-details cr-military-status">
+            <div class="span3 cr-label">
+                <label>
+                    For servicemember or veteran
+                </label>
+            </div>
+            <div class="row cr-question">
+                <div class="span3 cr-label cr-question-left">
+                    <label for="cr-current-status1">
+                        Current status
+                    </label>
+                    <select name="cr-current-status1" id="cr-current-status1">
+                        <option value="">Choose...</option>
+                        <option value="">Active</option>
+                        <option value="">Reserve</option>
+                        <option value="">National Guard</option>
+                        <option value="">Retired</option>
+                        <option value="">Veteran</option>
+                    </select>
+                </div>
+
+                <!-- middle name -->
+                <div class="span2 cr-label cr-question-right">
+                    <label for="cr-military-service1">
+                        Branch of service
+                    </label>
+                    <select name="cr-military-service1" id="cr-military-service1">
+                        <option value="">Choose...</option>
+                        <option value="">Marines</option>
+                        <option value="">Air Force</option>
+                        <option value="">Army</option>
+                        <option value="">Navy</option>
+                        <option value="">Coast Guard</option>
+                        <option value="">Public Health Service</option>
+                        <option value="">National Oceanic and Atmospheric Admin</option>
+                    </select>
+                </div>
+                <!-- /middle name -->
+            </div>
+
+            <div class="row cr-question cr-question-last">
+                <div class="span3 cr-label cr-question-left">
+                    <label for="cr-military-rank1">
+                        Rank <small class="inline">(Optional)</small>
+                    </label>
+
+                    <select name="cr-military-rank1" id="cr-military-rank1">
+                        <option value="">Choose...</option>
+                        <option value="">E1-E4</option>
+                        <option value="">E5-E7</option>
+                        <option value="">E8-E9</option>
+                        <option value="">O1-O3</option>
+                        <option value="">O4-O6</option>
+                        <option value="">O7-O10</option>
+                        <option value="">W01-CW5</option>
+                    </select>
+                </div>
+
+                <!-- suffix -->
+                <div class="span2 cr-label cr-question-right">
+                    <label for="cr-military-base1">
+                        Military base/location
+                        <small class="inline">(Optional)</small>
+                    </label>
+                    <select name="cr-military-base1" id="cr-military-base1">
+                        <option value="" disabled="disabled" selected="selected">Select...</option>
+                        <option value="">Minot Air Force Base</option>
+                        <option value="">McConnell Air Force Base</option>
+                        <option value="">Offutt Air Force Base</option>
+                        <option value="">Maxwell Air Force Base</option>
+                        <option value="">McClellan Air Force Base</option>
+                        <option value="">Fairchild Air Force Base</option>
+                    </select>
+                </div>
+                <!-- /suffix -->
+            </div>
+            <!-- /city and state -->
+        </fieldset>
+        <fieldset id="servicemember-details"
+                  class="cr-fieldset affiliation-details cr-military-status">
+            <div class="span3 cr-label">
+                <label>
+                    For spouse or dependent of servicemember or veteran
+                </label>
+            </div>
+            <div class="row cr-question">
+                <div class="span3 cr-label cr-question-left">
+                    <label for="cr-first-name2_4851476384792477">
+                        Current status
+                    </label>
+                    <select name="cr-current-status" id="cr-current-status">
+                        <option value="">Choose...</option>
+                        <option value="">Active</option>
+                        <option value="">Reserve</option>
+                        <option value="">National Guard</option>
+                        <option value="">Retired</option>
+                        <option value="">Veteran</option>
+                    </select>
+                </div>
+
+                <!-- middle name -->
+                <div class="span2 cr-label cr-question-right">
+                    <label for="cr-middle-name2_4851476384792477">
+                        Branch of service
+                    </label>
+                    <select name="cr-military-service" id="cr-military-service">
+                        <option value="">Choose...</option>
+                        <option value="">Marines</option>
+                        <option value="">Air Force</option>
+                        <option value="">Army</option>
+                        <option value="">Navy</option>
+                        <option value="">Coast Guard</option>
+                        <option value="">Public Health Service</option>
+                        <option value="">National Oceanic and Atmospheric Admin</option>
+                    </select>
+                </div>
+                <!-- /middle name -->
+            </div>
+
+            <div class="row cr-question cr-question-last">
+                <div class="span3 cr-label cr-question-left">
+                    <label for="cr-last-name2_4851476384792477">
+                        Rank <small class="inline">(Optional)</small>
+                    </label>
+
+                    <select name="cr-military-rank" id="cr-military-rank">
+                        <option value="">Choose...</option>
+                        <option value="">E1-E4</option>
+                        <option value="">E5-E7</option>
+                        <option value="">E8-E9</option>
+                        <option value="">O1-O3</option>
+                        <option value="">O4-O6</option>
+                        <option value="">O7-O10</option>
+                        <option value="">W01-CW5</option>
+                    </select>
+                </div>
+
+                <!-- suffix -->
+                <div class="span2 cr-label cr-question-right">
+                    <label for="cr-suffix2">
+                        Military base/location
+                        <small class="inline">(Optional)</small>
+                    </label>
+                    <select name="cr-suffix" id="cr-suffix2_4851476384792477">
+                        <option value="" disabled="disabled" selected="selected">Select...</option>
+                        <option value="">Minot Air Force Base</option>
+                        <option value="">McConnell Air Force Base</option>
+                        <option value="">Offutt Air Force Base</option>
+                        <option value="">Maxwell Air Force Base</option>
+                        <option value="">McClellan Air Force Base</option>
+                        <option value="">Fairchild Air Force Base</option>
+                    </select>
+                </div>
+                <!-- /suffix -->
+            </div>
+            <!-- /city and state -->
+        </fieldset>
     </div>
 </fieldset>
-
-<fieldset class="cr-fieldset identify-options someone-else">
-
-    <div class="row cr-question cr-question-last account-number-row">
-        <div class="span3 cr-label">
-           <p style="margin: 1em;">Be sure to include full contact information below.</p>
-       </div>
-
-        <!--
-                        <div class="span2 cr-label cr-question-right right-helper">
-                            <p></p>
-                        </div>
-                    -->
-                </div>
-            </fieldset>
 
 <!--
 
@@ -447,8 +662,8 @@ ADDITIONAL CONSUMER. SAME AS ABOVE CONTENT, MOSTLY
 
         <fieldset id="consumer2-identity" class="cr-fieldset additional-consumer">
             <!-- question -->
-            <div class="row cr-question">
-                <div class="span3 cr-label cr-question-left">
+            <div class="row cr-question cr-question-last">
+                <div class="span3 cr-label">
                     <label for="point-of-contact-identity">
                         How is this person involved in the complaint?
                         <div class='is-required'>Answer Required</div>
@@ -461,13 +676,11 @@ ADDITIONAL CONSUMER. SAME AS ABOVE CONTENT, MOSTLY
                         <option id="additional-consumer-identity-option3" class="consumer-identity-options" value="#">Joint account holder</option>
                         <option id="additional-consumer-identity-option4" class="consumer-identity-options" value="#">Additional card holder</option>
                     </select>
-
-                    <p class="ans-poc-other-who-spacer">&nbsp;</p>
                 </div>
             </div>
         </fieldset>
 
-        <fieldset class="cr-fieldset additional-consumer full-name-format">
+        <fieldset id="add-consumer" class="cr-fieldset additional-consumer full-name-format">
             <div class="row cr-question cr-question-last">
                 <!-- first name -->
                 <div class="span3 cr-label cr-question-col">
@@ -526,6 +739,22 @@ ADDITIONAL CONSUMER. SAME AS ABOVE CONTENT, MOSTLY
                 </div>
                 <!-- /suffix -->
             </div>
+
+            <div class="row cr-question">
+                <div class="span2 cr-label right-helper add-consumer">
+                    <label id="cr-add-consumer-checkbox">
+                        <input type="checkbox" name="no-email" value="no-email" class="cr-no-email checkbox" id="cr-add-consumer-full">
+                        Allow this person to access this complaint and receive status updates.
+                    </label>
+                </div>
+            </div>
+
+            <div class="row cr-question">
+                <p id="add-consumer-allow-access-disclosure">
+                Allowing full access may require documentation, such as a signed release form.
+                You can include an authorization document as an attachment on the next page.
+                </p>
+            </div>
         </fieldset>
 <!--
      <fieldset class="cr-fieldset additional-consumer">
@@ -545,31 +774,7 @@ ADDITIONAL CONSUMER. SAME AS ABOVE CONTENT, MOSTLY
     </fieldset>
 -->
 <fieldset id="additional-consumer-email" class="cr-fieldset additional-consumer">
-    <!-- email address -->
-    <div class="cr-question cr-question-last borrower-email additional-consumer-email">
-        <div class="span3 cr-label cr-question-left cr-question-with-checkbox">
-            <label for="con1-email">
-                Email address <small id="addcon-optional-status" class="inline">(Optional)</small>
-                <div class='is-required'>Optional</div>
-            </label>
-
-            <input type="email"
-                   name="cr-email2"
-                   id="cr-email2_2356852120719850"
-                   class="input-large left">
-            <p id="addcon-email-helper">We’ll use this email address to send updates about the status of this complaint. It will also be the additional consumer's username for logging in to their account.</p>
-        </div>
-
-        <div class="span2 cr-label cr-question-right right-helper add-consumer">
-            <label id="cr-add-consumer-checkbox" class="radio block">
-                <input type="checkbox" name="no-email" value="no-email" class="cr-no-email checkbox" id="cr-add-consumer-full">
-                Allow this person to access this complaint and receive status updates.
-            </label>
-        </div>
-    </div>
-
-    <div id="addcon-phone-number" class="row cr-question cr-question-last">
-
+    <div id="addcon-phone-number" class="row cr-question">
         <div id="address1"
              class="row cr-question address-template"
              data-label="Residence address">
@@ -585,6 +790,22 @@ ADDITIONAL CONSUMER. SAME AS ABOVE CONTENT, MOSTLY
             </div>
             <!-- /phone number -->
         </div>
+    </div>
+    <!-- email address -->
+    <div class="cr-question cr-question-last borrower-email additional-consumer-email">
+        <div class="span3 cr-label cr-question-left cr-question-with-checkbox">
+            <label for="con1-email">
+                Email address <small id="addcon-optional-status" class="inline">(Optional)</small>
+                <div class='is-required'>Optional</div>
+            </label>
+
+            <input type="email"
+                   name="cr-email2"
+                   id="cr-email2_2356852120719850"
+                   class="input-large left">
+            <p id="addcon-email-helper">We’ll use this email address to send updates about the status of this complaint. It will also be the additional consumer's username for logging in to their account.</p>
+        </div>
+    </div>
     </fieldset>
 </div>
 
@@ -634,9 +855,9 @@ POINT OF CONTACT
 
         <fieldset id="poc-relationship-to-consumer" class="cr-fieldset point-of-contact">
          <!-- question -->
-         <div class="row cr-question">
+         <div class="row cr-question cr-question-last">
 
-             <div class="span3 cr-label cr-question-left">
+             <div class="span3 cr-label">
                 <label for="point-of-contact-identity">
                     Relationship to consumer
                     <div class='is-required'>Answer Required</div>
@@ -652,18 +873,9 @@ POINT OF CONTACT
                     <option class="ans-rel-housing-counselor" value="housing-counselor">Housing counselor</option>
                     <option class="ans-rel-other" value="other">Other</option>
                 </select>
-
-                <p id="ans-poc-other-who-spacer">&nbsp;</p>
             </div>
-
-            <div id="poc-access-div" class="span2 cr-label cr-question-right right-helper add-consumer">
-                <label id="cr-add-consumer-checkbox" class="radio block">
-                    <input type="checkbox" name="no-email" value="no-email" class="cr-no-email checkbox" id="cr-add-poc-full">
-                    Allow this person full access to this complaint in addition to status updates.
-                </label>
-            </div>
-
         </div>
+
         <div class="row cr-question">
 
             <div id="ans-poc-other-who" class="selected_other cr-question cr-label cr-question-left cr-question-last">
@@ -680,73 +892,82 @@ POINT OF CONTACT
     </fieldset>
 
     <fieldset id="poc-disclosure" class="cr-fieldset">
-     <div class="row cr-question">
 
-         <p>Allowing full access may require documentation, such as a signed release form. You can include an authorization document as an attachment on the next page.</p>
-     </div>
+        <fieldset class="cr-fieldset point-of-contact">
 
- <fieldset class="cr-fieldset point-of-contact">
+            <div class="row cr-question">
+                <!-- first name -->
+                <div class="span3 cr-label cr-question-col">
+                    <label for="cr-first-name2_4851476384792477">
+                        First name
+                    </label>
+                    <input type="text" name="cr-first-name2" id="cr-first-name2_4851476384792477">
+                </div>
+                <!-- /first name -->
 
-    <div class="row cr-question cr-question-last">
-        <!-- first name -->
-        <div class="span3 cr-label cr-question-col">
-            <label for="cr-first-name2_4851476384792477">
-                First name
-            </label>
-            <input type="text" name="cr-first-name2" id="cr-first-name2_4851476384792477">
-        </div>
-        <!-- /first name -->
+                <!-- middle name -->
+                <div class="span3 cr-label cr-question-col">
+                    <label for="cr-middle-name2_4851476384792477">
+                        Middle <small class="inline">(Optional)</small>
+                    </label>
+                    <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477">
+                </div>
+                <!-- /middle name -->
 
-        <!-- middle name -->
-        <div class="span3 cr-label cr-question-col">
-            <label for="cr-middle-name2_4851476384792477">
-                Middle <small class="inline">(Optional)</small>
-            </label>
-            <input type="text" name="cr-middle-name2" id="cr-middle-name2_4851476384792477">
-        </div>
-        <!-- /middle name -->
+                <!-- last name -->
+                <div class="span3 cr-label cr-question-col">
+                    <label for="cr-last-name2_4851476384792477">
+                        Last name
+                        <div class='is-required'>Answer Required</div>
+                    </label>
 
-        <!-- last name -->
-        <div class="span3 cr-label cr-question-col">
-            <label for="cr-last-name2_4851476384792477">
-                Last name
-                <div class='is-required'>Answer Required</div>
-            </label>
+                    <input type="text"
+                           name="cr-last-name"
+                           id="cr-last-name2_4851476384792477">
+                </div>
+                <!-- /last name -->
 
-            <input type="text"
-                   name="cr-last-name"
-                   id="cr-last-name2_4851476384792477">
-        </div>
-        <!-- /last name -->
+                <!-- suffix -->
+                <div class="span3 cr-label cr-question-col">
+                    <label for="cr-suffix2">
+                        Suffix
+                        <small class="inline">(Optional)</small>
+                    </label>
+                    <select name="cr-suffix" id="cr-suffix2_4851476384792477">
+                        <option value="" disabled="disabled" selected="selected">Select...</option>
+                        <option value="">Jr</option>
+                        <option value="">Sr</option>
+                        <option value="">PhD</option>
+                        <option value="">DS</option>
+                        <option value="">Esq</option>
+                        <option value="">I</option>
+                        <option value="">II</option>
+                        <option value="">III</option>
+                        <option value="">IV</option>
+                        <option value="">V</option>
+                        <option value="">VI</option>
+                        <option value="">VII</option>
+                        <option value="">IX</option>
+                        <option value="">X</option>
+                    </select>
+                </div>
+                <!-- /suffix -->
+                </div>
 
-        <!-- suffix -->
-        <div class="span3 cr-label cr-question-col">
-            <label for="cr-suffix2">
-                Suffix
-                <small class="inline">(Optional)</small>
-            </label>
-            <select name="cr-suffix" id="cr-suffix2_4851476384792477">
-                <option value="" disabled="disabled" selected="selected">Select...</option>
-                <option value="">Jr</option>
-                <option value="">Sr</option>
-                <option value="">PhD</option>
-                <option value="">DS</option>
-                <option value="">Esq</option>
-                <option value="">I</option>
-                <option value="">II</option>
-                <option value="">III</option>
-                <option value="">IV</option>
-                <option value="">V</option>
-                <option value="">VI</option>
-                <option value="">VII</option>
-                <option value="">IX</option>
-                <option value="">X</option>
-            </select>
-        </div>
-        <!-- /suffix -->
-        </div>
-</fieldset>
-<!--
+                <div class="row cr-question">
+                    <div id="poc-access-div" class="span2 cr-label right-helper add-consumer">
+                        <label id="cr-add-consumer-checkbox">
+                            <input type="checkbox" name="no-email" value="no-email" class="cr-no-email checkbox" id="cr-add-poc-full">
+                            Allow this person full access to this complaint in addition to status updates.
+                        </label>
+                    </div>
+                </div>
+
+                <div class="row cr-question">
+                    <p id="poc-allow-access-disclosure">Allowing full access may require documentation, such as a signed release form. You can include an authorization document as an attachment on the next page.</p>
+                </div>
+            </fieldset>
+    <!--
      <fieldset class="cr-fieldset point-of-contact">
 
             <div class="row cr-question cr-question-last zipcode-row">
@@ -764,6 +985,26 @@ POINT OF CONTACT
     </fieldset>
 -->
 <fieldset id="poc-email-address" class="cr-fieldset point-of-contact">
+
+    <div id="poc-phone-number" class="row cr-question">
+
+        <div id="address2"
+             class="row cr-question address-template"
+             data-label="Residence address">
+            <!-- Handlebars will add address template here. -->
+        </div>
+
+        <div class="row cr-question">
+            <!-- phone number -->
+            <div class="span3 cr-label cr-question-left">
+                <label for="address2-phone">
+                    Phone number
+                </label>
+                <input type="text" id="address2-phone">
+            </div>
+            <!-- /phone number -->
+        </div>
+    </div>
     <!-- email address -->
     <div class="cr-question borrower-email">
         <div class="span3 cr-label cr-question-left cr-question-with-checkbox cr-question-last poc-email-address">
@@ -803,26 +1044,6 @@ POINT OF CONTACT
             </div>
 =-->
         <!-- /email  -->
-
-        <div id="poc-phone-number" class="row cr-question cr-question-last">
-
-            <div id="address2"
-                 class="row cr-question address-template"
-                 data-label="Residence address">
-                <!-- Handlebars will add address template here. -->
-            </div>
-
-            <div class="row cr-question cr-question-last">
-                <!-- phone number -->
-                <div class="span3 cr-label cr-question-left">
-                    <label for="address2-phone">
-                        Phone number
-                    </label>
-                    <input type="text" id="address2-phone">
-                </div>
-                <!-- /phone number -->
-            </div>
-        </div>
     </div>
 
 <!--
@@ -833,138 +1054,6 @@ END OF Point of contact
 
 -->
 
-<!--
-
-///////////////
-AFFILIATIONS
-///////////////
-
--->
-
-<div class="cr-primary-container">
-    <h3 id="affiliations-section">Affiliations</h3>
-    <p>We use this information to help identify trends in the marketplace.</p>
-    <fieldset class="cr-fieldset">
-
-        <!-- question -->
-        <div id="affiliation-question" class="row cr-question">
-
-            <div class="span3 cr-label">
-
-                <label for="cr-military-status">
-                    <span id='military-question'>The primary consumer is:</span>
-                    <small>(Optional, choose all that apply)</small>
-                </label>
-
-            </div>
-
-            <div id="affiliation-options" class="span9 cr-answer cr-radios cr-servicemember prodselect">
-
-                <label class="radio block">
-                    <input type="checkbox" name="cr-military-status" value="option1" class="cr-need-military-status" id="cr-military-status">
-                    A servicemember or veteran
-                </label>
-
-                <label class="radio block">
-                    <input type="checkbox" name="cr-military-status2" value="option2" class="cr-need-servicemember-info">
-                    The spouse or dependent of a servicemember or veteran
-                </label>
-                <label class="radio block">
-                    <input type="checkbox" name="cr-student" value="option3" class="cr-need-over-62">
-                    A current student
-                    <br/><small>Includes any college or university degree program</small>
-                </label>
-
-                <label class="radio block">
-                    <input type="checkbox" name="cr-justice-involved" value="option3" class="cr-need-over-62">
-                    A person with a disability
-                </label>
-            </div>
-
-        </div>
-        <!-- /question -->
-
-    </fieldset>
-    <fieldset id="servicemember-details" class="cr-fieldset affiliation-details cr-military-status">
-        <div class="row cr-question">
-
-            <div class="span3 cr-label cr-question-left">
-                <label for="cr-first-name2_4851476384792477">
-                    Current status
-                </label>
-                <select name="cr-current-status" id="cr-current-status">
-                    <option value="">Choose...</option>
-                    <option value="">Active</option>
-                    <option value="">Reserve</option>
-                    <option value="">National Guard</option>
-                    <option value="">Retired</option>
-                    <option value="">Veteran</option>
-                </select>
-
-            </div>
-
-            <!-- middle name -->
-            <div class="span2 cr-label cr-question-right">
-                <label for="cr-middle-name2_4851476384792477">
-                    Branch of service
-                </label>
-                <select name="cr-military-service" id="cr-military-service">
-                    <option value="">Choose...</option>
-                    <option value="">Marines</option>
-                    <option value="">Air Force</option>
-                    <option value="">Army</option>
-                    <option value="">Navy</option>
-                    <option value="">Coast Guard</option>
-                    <option value="">Public Health Service</option>
-                    <option value="">National Oceanic and Atmospheric Admin</option>
-                </select>
-
-            </div>
-            <!-- /middle name -->
-        </div>
-
-        <div class="row cr-question cr-question-last">
-            <div class="span3 cr-label cr-question-left">
-                <label for="cr-last-name2_4851476384792477">
-                    Rank <small class="inline">(Optional)</small>
-                </label>
-
-                <select name="cr-military-rank" id="cr-military-rank">
-                    <option value="">Choose...</option>
-                    <option value="">E1-E4</option>
-                    <option value="">E5-E7</option>
-                    <option value="">E8-E9</option>
-                    <option value="">O1-O3</option>
-                    <option value="">O4-O6</option>
-                    <option value="">O7-O10</option>
-                    <option value="">W01-CW5</option>
-                </select>
-
-            </div>
-
-            <!-- suffix -->
-            <div class="span2 cr-label cr-question-right">
-                <label for="cr-suffix2">
-                    Military base/location
-                    <small class="inline">(Optional)</small>
-                </label>
-                <select name="cr-suffix" id="cr-suffix2_4851476384792477">
-                    <option value="" disabled="disabled" selected="selected">Select...</option>
-                    <option value="">Minot Air Force Base</option>
-                    <option value="">McConnell Air Force Base</option>
-                    <option value="">Offutt Air Force Base</option>
-                    <option value="">Maxwell Air Force Base</option>
-                    <option value="">McClellan Air Force Base</option>
-                    <option value="">Fairchild Air Force Base</option>
-                </select>
-
-            </div>
-            <!-- /suffix -->
-        </div>
-        <!-- /city and state -->
-    </fieldset>
-
-</div>
 
 </div>
 


### PR DESCRIPTION
## Changes

- Moves affiliations section to primary consumer section.
- Makes affiliations checkboxes show current status sections concurrently.

## Testing

- `gulp clean && gulp build`
- Visit /your-information.html
- Check `The primary consumer doesn't have an email address`.
- Check `A servicemember or veteran` and `The spouse or dependent of a servicemember or veteran` checkboxes.

## Review

- @niqjohnson 

## Screenshots

![screen shot 2016-07-06 at 1 03 16 pm](https://cloud.githubusercontent.com/assets/704760/16627263/6ed1a06a-437a-11e6-9e33-cb95f4677312.png)


## Notes

- Contains https://github.com/cfpb/complaint-intake/pull/41
- Only updates primary consumer. Additional consumer and additional point of contact will be updated in a separate PR.
