### PR TITLE
Removes "Optional" text next to address fields when all fields are op…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Nothing.
 
 ### Changed
-- Nothing.
+- Removes "Optional" text next to address fields when all fields are optional.
 
 ### Deprecated
 - Nothing.

--- a/src/static/js/modules/international-addresses.js
+++ b/src/static/js/modules/international-addresses.js
@@ -40,7 +40,11 @@ function initOptions( context ) {
 
 function _initAddress( addressDom, id ) {
   var label = addressDom.getAttribute( 'data-label' );
-  addressDom.innerHTML = addressHandlebars( { id: id, label: label } );
+  if ( label !== 'Company address' ) {
+    addressDom.innerHTML = addressHandlebars( { id: id, label: label, addOptionalText: true } );
+  } else {
+    addressDom.innerHTML = addressHandlebars( { id: id, label: label, addOptionalText: false } );
+  }
   _countryDropdownDom = addressDom.querySelector( '#address-country-' + id );
   _addressMap[_countryDropdownDom.id] = addressDom;
   _countryDropdownDom.addEventListener( 'change', _countryChanged );
@@ -55,6 +59,10 @@ function _countryChanged( evt ) {
   // 100 is the value code for the USA.
   if ( evt.target.value !== '100' ) {
     opts.isInternational = true;
+  }
+
+  if ( label !== 'Company address' ) {
+    opts.addOptionalText = true;
   }
   _addressContainerDom = _addressMap[evt.target.id];
   _countryDropdownDom = _addressContainerDom.querySelector( '#address-country-' + id );

--- a/src/static/tmpl/address.handlebars
+++ b/src/static/tmpl/address.handlebars
@@ -406,7 +406,7 @@
 <div class="row cr-question">
     <div class="span3 cr-label cr-question-left">
         <label for="address-line2-{{id}}">
-            {{label}} line 2 <small class="inline">(Optional)</small>
+            {{label}} line 2 {{#if addOptionalText}}<small class="inline">(Optional)</small>{{/if}}
             <div class='is-required'>Answer Required</div>
         </label>
 
@@ -419,7 +419,7 @@
 <div class="row cr-question">
     <div class="span3 cr-label cr-question-left">
         <label for="address-line3-{{id}}">
-            {{label}} address line 3 <small class="inline">(Optional)</small>
+            {{label}} line 3 {{#if addOptionalText}}<small class="inline">(Optional)</small>{{/if}}
             <div class='is-required'>Answer Required</div>
         </label>
 


### PR DESCRIPTION
## Changes

- Removes "Optional" text next to address fields when all fields are optional.

## Testing

- `gulp clean && gulp build`
- Visit /company-information.html
- Enter an unknown company.
- Note that address line 2 is not labeled as optional.
- Find another address (such as additional company > credit reporting > check "company should also receive…" > Residence address + Date of birth

## Review

- @niqjohnson 

## Screenshots

![screen shot 2016-07-08 at 12 12 11 pm](https://cloud.githubusercontent.com/assets/704760/16693877/4acf0572-4505-11e6-9bda-4010e74f827f.png)

![screen shot 2016-07-08 at 12 12 04 pm](https://cloud.githubusercontent.com/assets/704760/16693878/4ad1ed50-4505-11e6-8fef-223485217c0d.png)
