### PR TITLE
General cleanup / added fieldsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 ## Unreleased
 
 ### Added
-- Nothing.
+- Where did you get the loan fieldset from debt collection/payday loan.
 
 ### Changed
-- Nothing.
+- Removes fieldset borders that were being applied outside of pagination.
+- Added `data-` prefix to data attributes.
+- Added second company to debt collection sub-products.
+- Added placeholder text for step 2 when product is not selected.
 
 ### Deprecated
 - Nothing.
@@ -13,7 +16,7 @@
 - Nothing.
 
 ### Fixed
-- Nothing.
+- Fixed toggle on dispute case section for all products.
 
 
 ## [0.10.2](https://cfpb.github.io/complaint-intake/versions/0.10.2/)

--- a/src/select-issue.html
+++ b/src/select-issue.html
@@ -156,7 +156,7 @@
 
 <div id="select_issue" class="cr-primary-container">
     <h2>What type of issue is your complaint about?</h2>
-    <p class="page-intro select-issue">Most of the <strong><span id="product-name-in-subhead">product name</span></strong> complaints we receive are about these types of issues.</p>
+    <p class="page-intro select-issue">Most of the <strong><span id="product-name-in-subhead">[no product selected]</span></strong> complaints we receive are about these types of issues.</p>
     <p class="page-intro2 extra-bottom">Select the issue that best describes your complaint, and on the next page we'll ask you to describe the issue in your own words. </p>
 
 

--- a/src/select-product.html
+++ b/src/select-product.html
@@ -287,17 +287,17 @@ What type of credit reporting product?
 <div id="subproduct_options" class="select-product-or-issue">
  <!--     -->
  <div id="mortgage_products" class="subproduct_sect mortgage_products">
-  <label id="home-mortgage" class="radio block" issues="mortgage">
+  <label id="home-mortgage" class="radio block" data-issues="mortgage">
     <input name="sec_selex" type="radio" class="radio_input_subpro"/>
     Home mortgage
     <br /><small></small>
   </label>
-  <label id="home-equity-line-of-credit" class="radio block" issues="mortgage">
+  <label id="home-equity-line-of-credit" class="radio block" data-issues="mortgage">
     <input name="sec_selex" type="radio" class="radio_input_subpro"/>
     Home equity line of credit
     <br /><small></small>
   </label>
-  <label id="reverse-mortgage" class="radio block" issues="mortgage">
+  <label id="reverse-mortgage" class="radio block" data-issues="mortgage">
     <input name="sec_selex" type="radio" class="radio_input_subpro"/>
     Reverse mortgage
     <br /><small></small>
@@ -307,18 +307,18 @@ What type of credit reporting product?
 
 <div id="student_loan_products" class="subproduct_sect student_loan_products">
 
-  <label id="federal-student-loan" class="radio block" issues="student_loan">
+  <label id="federal-student-loan" class="radio block" data-issues="student_loan">
     <input name="sec_selex" type="radio" class="radio_input_subpro"/>
     Federal student loan
     <br /><small>Stafford, Direct Subsidized, Direct Unsubsidized, consolidation, PLUS, Perkins, Federal Family Education Loan (FFEL)</small>
   </label>
-  <label id="private-student-loan" class="radio block" issues="student_loan">
+  <label id="private-student-loan" class="radio block" data-issues="student_loan">
     <input name="sec_selex" type="radio" class="radio_input_subpro"/>
     Private student loan
     <br /><small>Private, alternative, or co-signed loans; federal loans refinanced with a private lender; other student loans</small>
   </label>
 <!--
-            <label id="student-loan-unsure" class="radio block" issues="student_loan">
+            <label id="student-loan-unsure" class="radio block" data-issues="student_loan">
                 <input name="sec_selex" type="radio" class="radio_input_subpro"/>
                 I don't know
                 <br /><small></small>
@@ -328,12 +328,12 @@ What type of credit reporting product?
 
         <div id="vehicle_loan_products" class="subproduct_sect vehicle_loan_products">
 
-          <label id="vehicle-loan" class="radio block" issues="vehicle_loan">
+          <label id="vehicle-loan" class="radio block" data-issues="vehicle_loan">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Loan
             <br /><small></small>
           </label>
-          <label id="vehicle-lease" class="radio block" issues="vehicle_lease">
+          <label id="vehicle-lease" class="radio block" data-issues="vehicle_lease">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Lease
             <br /><small></small>
@@ -342,27 +342,27 @@ What type of credit reporting product?
 
         <fieldset id="consumer_loan_products" class="subproduct_sect consumer_loan_products">
 
-          <label id="payday-loan" class="radio block" addtlquestions="payday" issues="payday_loan">
+          <label id="payday-loan" class="radio block" data-addtlquestions="payday" data-issues="payday_loan">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Payday loan
             <br /><small></small>
           </label>
-          <label id="pawn-loan" class="radio block" addtlquestions="payday" issues="pawn_loan">
+          <label id="pawn-loan" class="radio block" data-addtlquestions="payday" data-issues="pawn_loan">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Pawn loan
             <br /><small></small>
           </label>
-          <label id="title-loan" class="radio block" addtlquestions="payday" issues="title_loan">
+          <label id="title-loan" class="radio block" data-addtlquestions="payday" data-issues="title_loan">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Title loan
             <br /><small></small>
           </label>
-          <label id="installment-loan" class="radio block" addtlquestions="payday" issues="installment_loan">
+          <label id="installment-loan" class="radio block" data-addtlquestions="payday" data-issues="installment_loan">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Installment loan
             <br /><small></small>
           </label>
-          <label id="personal-line-of-credit" class="radio block" issues="personal_line_of_credit">
+          <label id="personal-line-of-credit" class="radio block" data-issues="personal_line_of_credit">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Personal line of credit
             <br /><small></small>
@@ -371,49 +371,49 @@ What type of credit reporting product?
 
         <div id="card_products" class="subproduct_sect card_products">
 
-          <label id="credit-card" class="radio block" issues="credit_card">
+          <label id="credit-card" class="radio block" data-issues="credit_card">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Credit card
             <br /><small>Used for purchasing items on credit</small>
           </label>
-          <label id="gift-card" class="radio block" issues="prepaid_card">
+          <label id="gift-card" class="radio block" data-issues="prepaid_card">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Gift card
             <br /><small>Gift, loyalty or promotional card issued by a store</small>
           </label>
-          <label id="government-benefit-card" class="radio block" issues="prepaid_card">
+          <label id="government-benefit-card" class="radio block" data-issues="prepaid_card">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Government benefit card
             <br /><small>Used for Social Security, unemployment compensation or a tax refund</small>
           </label>
-          <label id="reloadable-prepaid-card" class="radio block" issues="prepaid_card">
+          <label id="reloadable-prepaid-card" class="radio block" data-issues="prepaid_card">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Reloadable prepaid card
             <br /><small>Used for shopping anywhere</small>
           </label>
-          <label id="ID-prepaid-card" class="radio block" issues="prepaid_card">
+          <label id="ID-prepaid-card" class="radio block" data-issues="prepaid_card">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             ID prepaid card
             <br /><small>Prepaid card attached to a student or other ID</small>
           </label>
-          <label id="mobile-wallet" class="radio block" issues="prepaid_card">
+          <label id="mobile-wallet" class="radio block" data-issues="prepaid_card">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Mobile wallet
             <br /><small>Used for making payments on your mobile phone</small>
           </label>
 
-          <label id="payroll-card" class="radio block" issues="prepaid_card">
+          <label id="payroll-card" class="radio block" data-issues="prepaid_card">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Payroll card
             <br /><small>Used for receiving your paycheck from your employer</small>
           </label>
 
-          <label id="transit-card" class="radio block" issues="prepaid_card">
+          <label id="transit-card" class="radio block" data-issues="prepaid_card">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Transit card
             <br /><small>A transit card that can be used for shopping anywhere</small>
           </label>
-          <label id="refund-anticipation" class="radio block" issues="refund_anticipation">
+          <label id="refund-anticipation" class="radio block" data-issues="refund_anticipation">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Refund anticipation card
             <br /><small>Used for receiving a tax refund</small>
@@ -422,29 +422,29 @@ What type of credit reporting product?
 
         <div id="checking_products" class="subproduct_sect checking_products">
 
-          <label id="checking-account" class="radio block" issues="checking_account">
+          <label id="checking-account" class="radio block" data-issues="checking_account">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Checking account
             <br /><small></small>
           </label>
 
-          <label id="savings-account" class="radio block" issues="savings_account">
+          <label id="savings-account" class="radio block" data-issues="savings_account">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Savings account
             <br /><small></small>
           </label>
-          <label id="certificate-of-deposit" class="radio block" issues="certificate_of_deposit">
+          <label id="certificate-of-deposit" class="radio block" data-issues="certificate_of_deposit">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             CD (Certificate of Deposit)
             <br /><small></small>
           </label>
-          <label id="other-bank-product-or-service" class="radio block" issues="checking_account">
+          <label id="other-bank-product-or-service" class="radio block" data-issues="checking_account">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Other bank product or service
             <br /><small></small>
           </label>
 <!--
-            <label id="cashing-a-check-without-an-account" class="radio block" issues="check_cashing">
+            <label id="cashing-a-check-without-an-account" class="radio block" data-issues="check_cashing">
                 <input name="sec_selex" type="radio" class="radio_input_subpro"/>
                 Cashing a check without an account
                 <br /><small></small>
@@ -455,58 +455,58 @@ What type of credit reporting product?
 
         <div id="money_trans_products" class="subproduct_sect money_trans_products">
 
-          <label id="domestic-money-transfer" class="radio block" issues="money_transfer">
+          <label id="domestic-money-transfer" class="radio block" data-issues="money_transfer">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Domestic (US) money transfer
             <br /><small></small>
           </label>
-          <label id="international-money-transfer" class="radio block" issues="money_transfer">
+          <label id="international-money-transfer" class="radio block" data-issues="money_transfer">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             International money transfer
             <br /><small></small>
           </label>
-          <label id="check-cashing" class="radio block" issues="check_cashing">
+          <label id="check-cashing" class="radio block" data-issues="check_cashing">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Check cashing
             <br /><small></small>
           </label>
-          <label id="mobile-wallet" class="radio block" issues="prepaid_card">
+          <label id="mobile-wallet" class="radio block" data-issues="prepaid_card">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Mobile wallet
             <br /><small></small>
           </label>
 
-          <label id="money-order" class="radio block" issues="money_order">
+          <label id="money-order" class="radio block" data-issues="money_order">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Money order
             <br /><small></small>
           </label>
 
-          <label id="refund-anticipation" class="radio block" issues="refund_anticipation">
+          <label id="refund-anticipation" class="radio block" data-issues="refund_anticipation">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Refund anticipation check
             <br /><small></small>
           </label>
 
-          <label id="traveler-or-cashier" class="radio block" issues="traveler_cashier_check">
+          <label id="traveler-or-cashier" class="radio block" data-issues="traveler_cashier_check">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Traveler's check or cashier's check
             <br /><small></small>
           </label>
 
-          <label id="foreign-currency-exchange" class="radio block" issues="fx_exchange">
+          <label id="foreign-currency-exchange" class="radio block" data-issues="fx_exchange">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Foreign currency exchange
             <br /><small></small>
           </label>
 
-          <label id="virtual-currency" class="radio block" issues="virtual_currency">
+          <label id="virtual-currency" class="radio block" data-issues="virtual_currency">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Virtual currency
             <br /><small></small>
           </label>
 
-          <label id="debt-settlement" class="radio block" issues="credit_repair">
+          <label id="debt-settlement" class="radio block" data-issues="credit_repair">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Debt settlement
             <br /><small></small>
@@ -516,48 +516,48 @@ What type of credit reporting product?
 
         <div id="debt_products" class="subproduct_sect debt_products">
 
-          <label id="credit-card-debt-collection" class="radio block" issues="debt_collection">
+          <label id="credit-card-debt-collection" class="radio block" data-issues="debt_collection">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Credit card debt
             <br /><small></small>
           </label>
-          <label id="mortgage-debt-collection" class="radio block" issues="debt_collection">
+          <label id="mortgage-debt-collection" class="radio block" data-issues="debt_collection">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Mortgage debt
             <br /><small></small>
           </label>
-          <label id="medical-debt-collection" class="radio block" issues="debt_collection">
+          <label id="medical-debt-collection" class="radio block" data-issues="debt_collection">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Medical debt
             <br /><small></small>
           </label>
-          <label id="payday-loan-debt-collection" class="radio block" issues="debt_collection">
+          <label id="payday-loan-debt-collection" class="radio block" data-addtlquestions="payday" data-issues="debt_collection">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Payday loan debt
             <br /><small></small>
           </label>
-          <label id="auto-debt-collection" class="radio block" issues="debt_collection">
+          <label id="auto-debt-collection" class="radio block" data-issues="debt_collection">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Auto debt
             <br /><small></small>
           </label>
-          <label id="federal-student-debt-collection" class="radio block" issues="debt_collection">
+          <label id="federal-student-debt-collection" class="radio block" data-issues="debt_collection">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Federal student loan debt
             <br /><small></small>
           </label>
 
-          <label id="non-federal-student-debt-collection" class="radio block" issues="debt_collection">
+          <label id="non-federal-student-debt-collection" class="radio block" data-issues="debt_collection">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Non-federal student loan debt
             <br /><small></small>
           </label>
-          <label id="other-debt-collection" class="radio block" issues="debt_collection">
+          <label id="other-debt-collection" class="radio block" data-issues="debt_collection">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Other debt
             <br /><small></small>
           </label>
-          <label id="unknown-debt-collection" class="radio block" issues="debt_collection">
+          <label id="unknown-debt-collection" class="radio block" data-issues="debt_collection">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             I do not know
             <br /><small></small>
@@ -566,12 +566,12 @@ What type of credit reporting product?
 
         <div id="credit_reporting_products" class="subproduct_sect credit_reporting_products">
 
-          <label id="credit-reporting" class="radio block" issues="credit_reporting">
+          <label id="credit-reporting" class="radio block" data-issues="credit_reporting">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Credit reporting or credit score
             <br /><small></small>
           </label>
-          <label id="credit-repair" class="radio block" issues="credit_repair">
+          <label id="credit-repair" class="radio block" data-issues="credit_repair">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
             Credit repair services
             <br /><small></small>

--- a/src/static/js/modules/dispute-case-number.js
+++ b/src/static/js/modules/dispute-case-number.js
@@ -5,7 +5,16 @@ var _caseNumberDom;
 
 function init() {
   var product = webStorageProxy.getItem( 'product_selected', localStorage );
-  if ( product === 'credit_reporting' ) {
+  if ( product === 'credit_reporting' ||
+       product === 'debt' ||
+       product === 'mortgage' ||
+       product === 'student_loan' ||
+       product === 'vehicle_loan' ||
+       product === 'card' ||
+       product === 'checking' ||
+       product === 'money_trans' ||
+       product === 'consumer_loan'
+    ) {
     // Handle showing dispute case number.
     var attemptedContactYesDom = document.querySelector( '#resolution-options-list' );
     _caseNumberDom = document.querySelector( '#case-number' );
@@ -17,15 +26,18 @@ function _showCaseInput( evt ) {
   var target = evt.target;
   var productId = 'product_selected';
   var product = webStorageProxy.getItem( productId, window.localStorage );
-  if ( target.id === 'contacted-company' &&
-       product === 'credit_reporting' ) {
+  if ( target.id === 'contacted-company' ) {
     // TODO: Remove when toggle buttons are working correctly.
     //       This is an awful hack to get the selecting to jump back and forth
     //       between the yes/no radio buttons correctly.
     document.querySelector( '#contacted-cfpb' ).parentNode.classList.remove( 'active' );
-    _caseNumberDom.classList.remove( 'u-hidden' );
   } else {
     document.querySelector( '#contacted-company' ).parentNode.classList.remove( 'active' );
+  }
+
+  if ( target.id === 'contacted-company' && product === 'credit_reporting' ) {
+    _caseNumberDom.classList.remove( 'u-hidden' );
+  } else {
     _caseNumberDom.classList.add( 'u-hidden' );
   }
 }

--- a/src/static/js/modules/step-company-information.js
+++ b/src/static/js/modules/step-company-information.js
@@ -141,9 +141,10 @@ function init() {
       var subproduct = webStorageProxy.getItem( 'subproduct_selected', localStorage );
       var issue = webStorageProxy.getItem( 'issue_selected', localStorage );
 
+      $( '#company-type-2' ).hide();
+
       /* alert(product + ', ' + subproduct + ', ' + issue); */
       switch ( product ) {
-
         case 'mortgage':
           $( '#company-intro-1' ).text( 'Mortgage company' );
           $( '#company-type-1' ).show();
@@ -195,17 +196,16 @@ function init() {
         case 'debt':
           $( '#company-intro-1' ).text( 'Debt collection company' );
           $( '#company-type-1' ).show();
+          $( '#company-type-2' ).show();
           $( '#identify-debt-collection-company' ).appendTo( '#company-type-1' );
           break;
 
         default:
           $( '#company-intro-1' ).text( 'Company information' );
           $( '#company-type-1' ).show();
-          $( '#company-type-2' ).hide();
-
       }
-      switch (subproduct) {
 
+      switch ( subproduct ) {
         case 'credit-repair':
           $( '#company-intro-1' ).text( 'Credit repair company' );
           $( '#company-type-1' ).show();
@@ -235,24 +235,53 @@ function init() {
           $( '#company-type-1' ).show();
           $( '#identify-credit-reporting-company' ).remove();
           $( '#identify-storefront-services-company' ).appendTo( '#company-type-1' );
-      }
-      switch (issue) {
 
-        case 'debt_collection':
-          $( '#company-intro-2' ).text( 'Debt collection company' );
-          $( '#company-type-2' ).show();
-          $( '#identify-debt-collection-company' ).appendTo( '#company-type-2' );
+        // Debt collection subproducts.
+        case 'credit-card-debt-collection':
+          $( '#company-intro-2' ).text( 'Credit card company' );
           break;
 
+        case 'mortgage-debt-collection':
+          $( '#company-intro-2' ).text( 'Mortgage company' );
+          break;
+
+        case 'medical-debt-collection':
+          $( '#company-intro-2' ).text( 'Medical company' );
+          break;
+
+        case 'payday-loan-debt-collection':
+          $( '#company-intro-2' ).text( 'Payday loan company' );
+          break;
+
+        case 'auto-debt-collection':
+          $( '#company-intro-2' ).text( 'Auto company' );
+          break;
+
+        case 'federal-student-debt-collection':
+          $( '#company-intro-2' ).text( 'Federal student loan company' );
+          break;
+
+        case 'non-federal-student-debt-collection':
+          $( '#company-intro-2' ).text( 'Non-federal student loan company' );
+          break;
+
+        case 'other-debt-collection':
+          $( '#company-intro-2' ).text( 'Other debt company' );
+          break;
+
+        case 'unknown-debt-collection':
+          $( '#company-intro-2' ).text( 'Unknown company' );
+          break;
+      }
+
+      switch ( issue ) {
         case 'credit_reporting':
           $( '#company-intro-2' ).text( 'Credit reporting company' );
           $( '#company-type-2' ).show();
           $( '#identify-credit-reporting-company' ).appendTo( '#company-type-2' );
           break;
-
-        default:
-          $( '#company-type-2' ).hide();
       }
+
       /*
       if ( $( '.company-name-input' ).val()) {
       $(this).closest( '.identify-product-options' ).slideDown(200);

--- a/src/static/js/modules/step-select-issue.js
+++ b/src/static/js/modules/step-select-issue.js
@@ -93,9 +93,11 @@ function init() {
     setTimeout( function() {
       // grab stuff from step 1
       var subproduct = webStorageProxy.getItem( 'subproduct_selected', localStorage );
-      var subproductname = subproduct.replace('-', ' ').replace('-', ' ').replace('-', ' ').replace('-', ' ').replace('-', ' ');
+      if ( subproduct ) {
+        var subproductname = subproduct.replace('-', ' ').replace('-', ' ').replace('-', ' ').replace('-', ' ').replace('-', ' ');
+        $( '#product-name-in-subhead' ).text( subproductname );
+      }
       var issuelist = webStorageProxy.getItem( 'issue_list', localStorage );
-      $( '#product-name-in-subhead' ).text( subproductname );
       $( '.all-topissues' ).hide();
       $( '#issue_options_' + issuelist ).slideDown( 200 );
       // $('#issue_options_' + issuelist).show();

--- a/src/static/js/modules/step-select-product.js
+++ b/src/static/js/modules/step-select-product.js
@@ -26,9 +26,9 @@ function init() {
 
       $( '#product_options label.active' ).removeClass( 'active' );
       $( '#select_subproduct' ).fadeIn( 'fast' );
-      $( '#' + $(this).attr( 'id' ) + '_label' ).fadeIn( 'fast' );
-      $( '#' + $(this).attr( 'id' ) + '_products' ).slideDown(200);
-      $(this).closest( 'label' ).addClass( 'active' );
+      $( '#' + $( this ).attr( 'id' ) + '_label' ).fadeIn( 'fast' );
+      $( '#' + $( this ).attr( 'id' ) + '_products' ).slideDown(200);
+      $( this ).closest( 'label' ).addClass( 'active' );
     }
   } );
 
@@ -36,24 +36,26 @@ function init() {
     if ( $( '.radio_input_subpro' ).is( ':checked' ) ) {
       $( '#subproduct_options label.active' ).removeClass( 'active' );
       $( '.product-specific-questions label.active' ).removeClass( 'active' );
-      $(this).closest( 'label' ).addClass( 'active' );
+      $( this ).closest( 'label' ).addClass( 'active' );
 
-      if ( $(this).parent().attr( 'addtlquestions' ) == 'payday' ){
+      if ( $( this ).parent().attr( 'data-addtlquestions' ) === 'payday' ){
         $( '#payday_questions' ).slideDown().show();
         $( '#payday_questions .follow-up' ).hide();
       } else {
-       $( '#payday_questions' ).hide();
+        $( '#payday_questions' ).slideUp();
       }
-      if ( $(this).parent().attr( 'id' ) == 'federal-student-loan' ){
+
+      if ( $( this ).parent().attr( 'id' ) === 'federal-student-loan' ){
         $( '#student_questions' ).slideDown().show();
-      } else if ( $(this).parent().attr( 'id' ) == 'private-student-loan' ){
+      } else if ( $( this ).parent().attr( 'id' ) === 'private-student-loan' ){
         $( '#student_questions' ).slideDown().show();
       } else {
         $( '#student_questions' ).slideUp();
       }
-      if ( $(this).parent().attr( 'id' ) == 'vehicle-loan' ){
+
+      if ( $( this ).parent().attr( 'id' ) === 'vehicle-loan' ){
         $( '#vehicle_questions' ).slideDown().show();
-      } else if ( $(this).parent().attr( 'id' ) == 'vehicle-lease' ){
+      } else if ( $( this ).parent().attr( 'id' ) === 'vehicle-lease' ){
         $( '#vehicle_questions' ).slideDown().show();
       } else {
         $( '#vehicle_questions' ).slideUp();
@@ -64,13 +66,13 @@ function init() {
   $( '.product-specific-questions .radio_input_subpro' ).on( 'change', function(){
     if ( $( '.radio_input_subpro' ).is( ':checked' ) ) {
       $( '.product-specific-questions label.active' ).removeClass( 'active' );
-      $(this).closest( 'label' ).addClass( 'active' );
-      if ( $(this).parent().attr( 'id' ) == 'at-store' ){
+      $( this ).closest( 'label' ).addClass( 'active' );
+      if ( $( this ).parent().attr( 'id' ) === 'at-store' ){
         $( '#store-questions' ).slideDown().show();
       } else {
         $( '#store-questions' ).hide();
       }
-      if ( $(this).parent().attr( 'id' ) == 'online' ){
+      if ( $( this ).parent().attr( 'id' ) === 'online' ){
         $( '#online-questions' ).slideDown().show();
       } else {
         $( '#online-questions' ).hide();
@@ -92,12 +94,12 @@ function init() {
       $( '#subproduct_options .radio' ).click( function(){
         // save the subproduct to local storage
         var subpro = $( this ).attr( 'id' );
-        var issuelist = $( this ).attr( 'issues' );
+        var issuelist = $( this ).attr( 'data-issues' );
         webStorageProxy.setItem( 'issue_list', issuelist, localStorage );
         webStorageProxy.setItem( 'subproduct_selected', subpro, localStorage );
 
         /*
-        if ( $(this).attr('id') == 'payday-loan' ){
+        if ( $( this ).attr('id') === 'payday-loan' ){
           alert('payday is happening.');
         }
         // alert(subpro + ', ' + issuelist);

--- a/src/v0/form/css/complain.css
+++ b/src/v0/form/css/complain.css
@@ -477,7 +477,14 @@ cruxform .cr-question-left input.accountinput {
 }
 
 fieldset {
-    margin:0px;
+    margin: 0;
+}
+
+/* Override pagination fieldset settings. */
+.content fieldset {
+    border: none;
+    margin: 0;
+    padding: 0;
 }
 
 .cr-label label,


### PR DESCRIPTION
## Additions

- Added "Where did you get the loan" fieldset from debt collection/payday loan.

## Changes

- Removes fieldset borders that were being applied outside of pagination.
- Added `data-` prefix to data attributes.
- Added second company to debt collection sub-products.
- Added placeholder text for step 2 when product is not selected.
- Fixed toggle on dispute case section for all products.

## Testing

- `gulp clean && gulp build`
- In Step 1, select Debt collection and select Payday loan debt.
- Proceed to step 4 and the second company field should show "Payday loan company."
- All debt collection products selected should show the second company field on step 4.

## Review

- @niqjohnson 

## Screenshots

![screen shot 2016-07-12 at 10 54 20 am](https://cloud.githubusercontent.com/assets/704760/16771908/30980b0e-4820-11e6-84ee-51d6c202bc02.png)

![screen shot 2016-07-12 at 10 57 43 am](https://cloud.githubusercontent.com/assets/704760/16771895/23c5a026-4820-11e6-8d18-d389a8beb787.png)
