### PR TITLE
Made identify options a template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Added `data-` prefix to data attributes.
 - Added second company to debt collection sub-products.
 - Added placeholder text for step 2 when product is not selected.
+- Made "how should this company identify you" section a template.
+- Updated product option combinations.
+- Updated company name selection to handle proper state when removing name.
 
 ### Deprecated
 - Nothing.

--- a/src/company-information.html
+++ b/src/company-information.html
@@ -262,6 +262,7 @@ COMPANY-1
     </fieldset><!-- not-boarded -->
 
     <!-- THIS IS WHERE THE OPTIONS GO! -->
+    <div class="identify-product-options"></div>
 
 </div> <!-- company-type 1 -->
 
@@ -383,6 +384,8 @@ COMPANY-2
     </fieldset><!-- not-boarded -->
 
 <!-- THIS IS WHERE THE OPTIONS GO! -->
+<div class="identify-product-options">
+</div>
 
 </div> <!-- company-type -->
 
@@ -409,7 +412,7 @@ ADDITIONAL COMPANY
 
 -->
 
-<div id="additional-company-div" class="cr-primary-container">
+<div id="company-type-3" class="cr-primary-container">
     <h3 id="additional-company">Additional company</h3>
     <fieldset class="cr-fieldset">
         <!-- question -->
@@ -459,12 +462,32 @@ ADDITIONAL COMPANY
                     <option class="ans-con1-coborrower" value="card">Credit or prepaid card</option>
                     <option class="ans-con1-coborrower" value="checking">Checking or savings account</option>
                     <option class="ans-con1-coborrower" value="money_trans">Money transfer or money service</option>
-                    <option class="ans-con1-coborrower" value="consumer_loan">Payday, online, store, or other loan</option>
+                    <option class="ans-con1-coborrower" value="consumer_loan">Payday, store, or other loan</option>
                 </select>
 
                 <div id="ans-rel-other-who" style="display:none;">
                     <input type="text" class="input-medium" name="cr-con1-other-who" id="cr-con1-other-who" placeholder="">
                 </div>
+
+                <select name="additional-consumer-identity2" id="additional-consumer-identity2" class="input-medium">
+                    <option>Select sub-product...</option>
+                    <option class="ans-con1-coborrower" value="credit-reporting">Credit reporting or credit score</option>
+                    <option class="ans-con1-coborrower" value="credit-repair">Credit repair services</option>
+                </select>
+
+                <select name="additional-consumer-identity3" id="additional-consumer-identity3" class="input-medium">
+                    <option>Select sub-product...</option>
+                    <option class="ans-con1-coborrower" value="domestic-money-transfer">Domestic (US) money transfer</option>
+                    <option class="ans-con1-coborrower" value="international-money-transfer">International money transfer</option>
+                    <option class="ans-con1-coborrower" value="check-cashing">Check cashing</option>
+                    <option class="ans-con1-coborrower" value="mobile-wallet">Mobile wallet</option>
+                    <option class="ans-con1-coborrower" value="money-order">Money order</option>
+                    <option class="ans-con1-coborrower" value="refund-anticipation">Refund anticipation check</option>
+                    <option class="ans-con1-coborrower" value="traveler-or-cashier">Traveler's check or cashier's check</option>
+                    <option class="ans-con1-coborrower" value="foreign-currency-exchange">Foreign currency exchange</option>
+                    <option class="ans-con1-coborrower" value="virtual-currency">Virtual currency</option>
+                    <option class="ans-con1-coborrower" value="debt-settlement">Debt settlement</option>
+                </select>
 
             </div>
         </div>
@@ -566,6 +589,8 @@ ADDITIONAL COMPANY
             </div>
         </div>
     </fieldset><!-- not-boarded -->
+
+    <div class="identify-product-options"></div>
 </div>
 <!--
 
@@ -642,600 +667,6 @@ END OF Additional Company
                 </div>
 
             </fieldset>
-
-<!--
-/////
-MORTGAGE OPTIONS.
-/////
--->
-
-<fieldset id="identify-mortgage-company" class="cr-fieldset identify-product-options">
-
-    <div class="row cr-question">
-        <div class="span3 cr-label">
-            <label>
-                How should this company identify you?
-                <div class='is-required'>Required</div>
-            </label>
-
-        </div>
-
-        <div class="span9 cr-answer cr-radios cr-behalf prodselect">
-            <label class="radio block">
-                <input type="radio" class='identify-account identification-type loan-number' name="identify-account" value="loan-number">
-                Loan number
-            </label>
-
-            <label class="radio block">
-                <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
-                Account number
-            </label>
-
-            <label class="radio block last">
-                <input type="radio" class='identify-account identification-type residence-address' name="identify-account" value="residence-address">
-                Residence address
-            </label>
-
-            <label class="radio block last">
-                <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
-                Billing address
-            </label>
-
-        </div>
-    </div>
-
-</fieldset>
-
-<!--
-/////
-STUDENT LOAN OPTIONS.
-/////
--->
-
-<fieldset id="identify-student-loan-company" class="cr-fieldset identify-product-options">
-
-    <div class="row cr-question">
-        <div class="span3 cr-label">
-            <label>
-                How should this company identify you?
-                <div class='is-required'>Required</div>
-            </label>
-
-        </div>
-
-        <div class="span9 cr-answer cr-radios cr-behalf prodselect">
-            <label class="radio block">
-                <input type="radio" class='identify-account identification-type loan-number' name="identify-account" value="loan-number">
-                Loan number
-            </label>
-
-            <label class="radio block">
-                <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
-                Account number
-            </label>
-
-            <label class="radio block last">
-                <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
-                Billing address
-            </label>
-
-            <label class="radio block last">
-                <input type="radio"
-                       class='identify-account
-                             identification-type
-                             social-security-number'
-                       name="identify-account"
-                       value="social-security-number">
-                Social security number
-            </label>
-
-        </div>
-    </div>
-
-</fieldset>
-
-<!--
-/////
-PAYDAY & INSTALLMENT LOAN OPTIONS.
-/////
--->
-
-<fieldset id="identify-payday-other-loan-company" class="cr-fieldset identify-product-options">
-
-    <div class="row cr-question">
-        <div class="span3 cr-label">
-            <label>
-                How should this company identify you?
-                <div class='is-required'>Required</div>
-            </label>
-
-        </div>
-
-        <label class="radio block">
-            <input type="radio" class='identify-account identification-type loan-number' name="identify-account" value="loan-number">
-            Loan number
-        </label>
-
-        <label class="radio block last">
-            <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
-            Billing address
-        </label>
-    </div>
-</div>
-
-</fieldset>
-
-<!--
-/////
-VEHICLE LOAN OR LEASE OPTIONS.
-/////
--->
-
-<fieldset id="identify-vehicle-loan-company" class="cr-fieldset identify-product-options">
-
-    <div class="row cr-question">
-        <div class="span3 cr-label">
-            <label>
-                How should this company identify you?
-                <div class='is-required'>Required</div>
-            </label>
-
-        </div>
-
-        <div class="span9 cr-answer cr-radios prodselect cr-behalf">
-            <label class="radio block">
-                <input type="radio" class='identify-account identification-type loan-number' name="identify-account" value="loan-number">
-                Loan number
-            </label>
-
-            <label class="radio block">
-                <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
-                Account number
-            </label>
-
-            <label class="radio block last">
-                <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
-                Billing address
-            </label>
-        </div>
-    </div>
-
-</fieldset>
-
-<!--
-/////
-CHECKING OR SAVINGS OPTIONS.
-/////
--->
-
-<fieldset id="identify-checking-savings-company" class="cr-fieldset identify-product-options">
-
-    <div class="row cr-question">
-        <div class="span3 cr-label">
-            <label>
-                How should this company identify you?
-                <div class='is-required'>Required</div>
-            </label>
-
-        </div>
-        <div class="span9 cr-answer cr-radios prodselect cr-behalf">
-            <label class="radio block">
-                <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
-                Account number
-            </label>
-
-            <label class="radio block last">
-                <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
-                Billing address
-            </label>
-        </div>
-    </div>
-
-</fieldset>
-
-<!--
-/////
-MONEY TRANSFER OPTIONS.
-/////
--->
-
-<fieldset id="identify-money-transfer-company" class="cr-fieldset identify-product-options">
-
-    <div class="row cr-question">
-        <div class="span3 cr-label">
-            <label>
-                How should this company identify you?
-                <div class='is-required'>Required</div>
-            </label>
-
-        </div>
-
-        <div class="span9 cr-answer cr-radios prodselect cr-behalf">
-            <label class="radio block">
-                <input type="radio"
-                       class="identify-account
-                              identification-type
-                              account-number"
-                       name="identify-account"
-                       value="account-number">
-                Account number
-            </label>
-
-            <label class="radio block">
-                <input type="radio"
-                       class="identify-account
-                              identification-type
-                              transaction-number"
-                       name="identify-account"
-                       value="transaction-number">
-                Transaction number
-            </label>
-
-        </div>
-    </div>
-
-</fieldset>
-
-<!--
-/////
-CREDIT REPORTING OPTIONS.
-/////
--->
-
-<fieldset id="identify-credit-reporting-company" class="cr-fieldset identify-product-options">
-
-    <div class="row cr-question">
-        <div class="span3 cr-label">
-            <label>
-                How should this company identify you?
-                <div class='is-required'>Required</div>
-            </label>
-
-        </div>
-
-        <div class="span9 cr-answer cr-radios prodselect cr-behalf">
-            <label class="radio block">
-                <input type="radio"
-                       class="identify-account
-                              identification-type
-                              account-number"
-                       name="identify-account"
-                       value="account-number">
-                Account number
-            </label>
-
-            <label class="radio block last">
-                <input type="radio"
-                       class="identify-account
-                              identification-type
-                              address-dob"
-                       name="identify-account"
-                       value="address-dob">
-                Residence address + Date of birth
-            </label>
-            <label class="radio block last">
-                <input type="radio"
-                       class="identify-account
-                              identification-type
-                              social-security-number"
-                       name="identify-account"
-                       value="social-security-number">
-                Social security number
-            </label>
-        </div>
-    </div>
-
-</fieldset>
-
-<!--
-/////
-DEBT COLLECTION OPTIONS.
-/////
--->
-
-<fieldset id="identify-debt-collection-company" class="cr-fieldset identify-product-options">
-
-    <div class="row cr-question">
-        <div class="span3 cr-label cr-question-left identify-debt-collection-company-phone">
-            <label for="cr-first-name2_4851476384792477">
-                What phone number has been receiving calls from this debt collector?
-            </label>
-            <input type="text"
-                   name="company-account"
-                   id="company-account"
-                   class="accountinput"
-                   placeholder="">
-        </div>
-    </div>
-
-    <div class="row cr-question">
-        <div class="span3 cr-label">
-            <label>
-                How should this company identify you?
-                <div class='is-required'>Required</div>
-            </label>
-
-        </div>
-
-        <div class="span9 cr-answer cr-radios prodselect cr-behalf">
-            <label class="radio block">
-                <input type="radio"
-                       class="identify-account
-                              identification-type
-                              account-number"
-                       name="identify-account"
-                       value="account-number">
-                Account number
-            </label>
-
-            <label class="radio block last">
-                <input type="radio"
-                       class="identify-account
-                              identification-type
-                              social-security-last-four"
-                       name="identify-account"
-                       value="social-security-last-four">
-                Last four digits of Social Security Number
-            </label>
-
-            <label class="radio block">
-                <input type="radio"
-                       class="identify-account
-                              identification-type
-                              loan-number"
-                       name="identify-account"
-                       value="loan-number">
-                Loan number
-            </label>
-
-        </div>
-    </div>
-
-</fieldset>
-
-
-<!--
-/////
-CREDIT REPAIR, DEBT SETTLEMENT OPTIONS.
-/////
--->
-
-<fieldset id="identify-credit-debt-repair-company" class="cr-fieldset identify-product-options">
-
-    <div class="row cr-question">
-        <div class="span3 cr-label">
-            <label>
-                How should this company identify you?
-                <div class='is-required'>Required</div>
-            </label>
-
-        </div>
-
-        <div class="span9 cr-answer cr-radios prodselect cr-behalf">
-            <label class="radio block">
-                <input type="radio"
-                       class="identify-account
-                              identification-type
-                              account-number"
-                       name="identify-account"
-                       value="account-number">
-                Account number
-            </label>
-
-            <label class="radio block last">
-                <input type="radio"
-                       class="identify-account
-                              identification-type
-                              billing-address"
-                       name="identify-account"
-                       value="billing-address">
-                Billing address
-            </label>
-
-        </div>
-    </div>
-
-</fieldset>
-
-<!--
-/////
-STOREFRONT SERVICES OPTIONS.
-/////
--->
-
-<fieldset id="identify-storefront-services-company" class="cr-fieldset identify-product-options">
-
-    <div class="row cr-question">
-        <div class="span3 cr-label">
-            <label>
-                How should this company identify you?
-                <div class='is-required'>Required</div>
-            </label>
-
-        </div>
-
-        <div class="span9 cr-answer cr-radios prodselect cr-behalf">
-            <label class="radio block">
-                <input type="radio"
-                       class="identify-account
-                              identification-type
-                              account-number"
-                       name="identify-account"
-                       value="account-number">
-                Account number
-            </label>
-
-            <label class="radio block">
-                <input type="radio"
-                       class="identify-account
-                              identification-type
-                              transaction-number"
-                       name="identify-account"
-                       value="transaction-number">
-                Transaction number
-            </label>
-
-            <label class="radio block last">
-                <input type="radio"
-                       class="identify-account
-                              identification-type
-                              billing-address"
-                       name="identify-account"
-                       value="billing-address">
-                Billing address
-            </label>
-
-        </div>
-    </div>
-
-</fieldset>
-
-<!--
-/////
-MOST PREPAIDS OPTIONS.
-/////
--->
-
-<fieldset id="identify-most-prepaids-company" class="cr-fieldset identify-product-options">
-
-    <div class="row cr-question">
-        <div class="span3 cr-label">
-            <label>
-                How should this company identify you?
-                <div class='is-required'>Required</div>
-            </label>
-
-        </div>
-
-        <div class="span9 cr-answer cr-radios prodselect cr-behalf">
-            <label class="radio block">
-                <input type="radio"
-                       class="identify-account
-                              identification-type
-                              account-number"
-                       name="identify-account"
-                       value="account-number">
-                Account number
-            </label>
-
-            <label class="radio block">
-                <input type="radio"
-                       class="identify-account
-                              identification-type
-                              card-number"
-                       name="identify-account"
-                       value="card-number">
-                Card number
-            </label>
-
-            <label class="radio block last">
-                <input type="radio"
-                       class="identify-account
-                              identification-type
-                              billing-address"
-                       name="identify-account"
-                       value="billing-address">
-                Billing address
-            </label>
-
-        </div>
-    </div>
-
-</fieldset>
-
-<!--
-/////
-PAYROLL AND GOVT PREPAIDS OPTIONS.
-/////
--->
-
-<fieldset id="identify-payroll-govt-prepaid-company" class="cr-fieldset identify-product-options">
-
-    <div class="row cr-question">
-        <div class="span3 cr-label">
-            <label>
-                How should this company identify you?
-                <div class='is-required'>Required</div>
-            </label>
-
-        </div>
-
-        <div class="span9 cr-answer cr-radios prodselect cr-behalf">
-            <label class="radio block">
-                <input type="radio"
-                       class="identify-account
-                              identification-type
-                              account-number"
-                       name="identify-account"
-                       value="account-number">
-                Account number
-            </label>
-
-            <label class="radio block">
-                <input type="radio"
-                       class="identify-account
-                              identification-type
-                              card-number"
-                       name="identify-account"
-                       value="card-number">
-                Card number
-            </label>
-
-            <label class="radio block last">
-                <input type="radio"
-                       class="identify-account
-                              identification-type
-                              billing-address"
-                       name="identify-account"
-                       value="billing-address">
-                Billing address
-            </label>
-
-        </div>
-    </div>
-
-</fieldset>
-
-<!--
-/////
-MOBILE WALLET OPTIONS.
-/////
--->
-
-<fieldset id="identify-mobile-wallet-company" class="cr-fieldset identify-product-options">
-
-    <div class="row cr-question">
-        <div class="span3 cr-label">
-            <label>
-                How should this company identify you?
-                <div class='is-required'>Required</div>
-            </label>
-
-        </div>
-
-        <div class="span9 cr-answer cr-radios prodselect cr-behalf">
-            <label class="radio block">
-                <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
-                Account number
-            </label>
-
-            <label class="radio block">
-                <input type="radio" class='identify-account identification-type email-address' name="identify-account" value="email-address">
-                Email address on account
-            </label>
-
-        </div>
-    </div>
-
-</fieldset>
-
-<!--
-
-////////////////////////////////////////////
-    End of product-specific options
-////////////////////////////////////////////
-
--->
 
 <!--
 

--- a/src/select-product.html
+++ b/src/select-product.html
@@ -210,7 +210,7 @@
 
             <label class="radio block">
               <input name="radio_" type="radio" class="radio_input product consumer_loan" id="consumer_loan" />
-              Payday, online, store, or other loan
+              Payday, store, or other loan
               <br /><small></small>
             </label>
           </div>
@@ -549,7 +549,7 @@ What type of credit reporting product?
 
           <label id="non-federal-student-debt-collection" class="radio block" data-issues="debt_collection">
             <input name="sec_selex" type="radio" class="radio_input_subpro"/>
-            Non-federal student loan debt
+            Private student loan debt
             <br /><small></small>
           </label>
           <label id="other-debt-collection" class="radio block" data-issues="debt_collection">

--- a/src/static/js/modules/companies-autocomplete.js
+++ b/src/static/js/modules/companies-autocomplete.js
@@ -1537,99 +1537,46 @@ function _companySelected3( suggestion ) {
 function _companySelected( suggestion, step ) {
   var companymessage = suggestion.message;
   var optionsID = suggestion.data;
-  var automatched = 'matched';
   $( '#' + optionsID ).appendTo( '#company-name-fieldset-' + step ).show().slideDown();
   $( '#forward-company' + step ).html( companymessage );
-  if ( automatched === 'matched' ) {
-    $( '#company' + step + '-not-boarded' ).hide();
-  }
+  _checkCompanyInput( suggestion.value, step );
 }
 
-function _checkCompanyInput( i ) {
+function _checkCompanyInput( value, i ) {
   $( '#company' + i + '-not-boarded' ).hide();
-}
-
-function _checkCompanyInput1( value ) {
-  _checkCompanyInput();
-  $( '#company-type-1 .identify-product-options' ).hide();
-
-  // If the company entered is not in the array, ask for more info.
-  var companyentered = value;
-  if ( companyentered !== '' ) {
+  $( '#company-type-' + i + ' .identify-product-options' ).hide();
+  if ( value !== '' ) {
+    var matchFound = false;
     $.each( _companies, function( index, element ) {
-      $( '#company1-not-boarded' ).removeClass( 'company-matched' );
-      var val = element.value;
-      if ( val === companyentered ) {
-        $( '#company1-not-boarded' ).addClass( 'company-matched' );
+      if ( element.value === value ) {
+        matchFound = true;
       }
     } );
-    $( '#company1-not-boarded' ).show().slideDown();
-    $( '#company1-not-boarded.company-matched' ).hide();
-    // show product options based on product type (see function in main.js)
-    $( '#company-type-1 .identify-product-options' ).slideDown();
-  }
-}
 
-function _checkCompanyInput2( value ) {
-  _checkCompanyInput();
-  //$( '#company-type-2 .identify-product-options .row:last-child' ).hide();
-  //$( '#company-type-2 .identify-product-options' ).slideDown();
+    if ( matchFound ) {
+      $( '#company' + i + '-not-boarded' ).slideUp();
+    } else {
+      $( '#company' + i + '-not-boarded' ).slideDown();
+    }
 
-  // If the company entered is not in the array, ask for more info
-  var companyentered = value;
-  if ( companyentered !== '' ) {
-    $.each( _companies, function( index, element ) {
-      $( '#company2-not-boarded' ).removeClass( 'company-matched' );
-      var val = element.value;
-      if ( val === companyentered ) {
-        $( '#company2-not-boarded' ).addClass( 'company-matched' );
-      }
-    } );
-    $( '#company2-not-boarded' ).show().slideDown();
-    $( '#company2-not-boarded.company-matched' ).hide();
-    // show product options based on product type (see function in main.js)
-    //$( '#company-type-2 .identify-product-options .row:last-child' ).hide();
-    //$( '#company-type-2 .identify-product-options' ).slideDown();
-  }
-}
-
-function _checkCompanyInput3( value ) {
-  _checkCompanyInput();
-  $( '#company-type-3 .identify-product-options' ).slideDown();
-
-  // If the company entered is not in the array, ask for more info
-  var companyentered = value;
-
-  if ( companyentered !== '' ) {
-    $.each( _companies, function( index, element ) {
-        $( '#company3-not-boarded' ).removeClass( 'company-matched' );
-        var val = element.value;
-        if ( val === companyentered ) {
-            $( '#company3-not-boarded' ).addClass( 'company-matched' );
-        }
-     });
-    $( '#company3-not-boarded' ).show().slideDown();
-    $( '#company3-not-boarded.company-matched' ).hide();
-    // show product options based on product type (see function in main.js)
-    $( '#company-type-3 .identify-product-options' ).slideDown();
+    if ( i === 1 || $( '#company' + i + '-forward' ).is( ':checked' ) ) {
+      // Show product options based on product type.
+      $( '#company-type-' + i + ' .identify-product-options' ).slideDown();
+    }
+  } else if ( i > 1 && $( '#company' + i + '-forward' ).is( ':checked' ) ) {
+    $( '#company' + i + '-forward' ).click();
   }
 }
 
 var _functMap = {
   '_companySelected1':   _companySelected1,
-  '_checkCompanyInput1': _checkCompanyInput1,
   '_companySelected2':   _companySelected2,
-  '_checkCompanyInput2': _checkCompanyInput2,
   '_companySelected3':   _companySelected3,
-  '_checkCompanyInput3': _checkCompanyInput3
 }
 
 function _setEvents( i ) {
-  $( '#company' + i + '-name' ).change( function() {
-    _functMap[ '_checkCompanyInput' + i ]( $( this ).val() );
-  } );
   $( '#company' + i + '-name' ).focusout( function() {
-    _functMap[ '_checkCompanyInput' + i ]( $( this ).val() );
+    _checkCompanyInput( $( this ).val(), i );
   } );
 }
 

--- a/src/static/js/modules/step-company-information.js
+++ b/src/static/js/modules/step-company-information.js
@@ -3,6 +3,70 @@
 var companiesAutocomplete = require( './companies-autocomplete' );
 var internationalAddresses = require( './international-addresses' );
 var webStorageProxy = require( '../modules/util/web-storage-proxy' );
+var identifyOptionsHandlebars = require( '../../tmpl/identify-options.handlebars' );
+
+// Initialize the "how should this company identify you" options.
+var _mortgageOptions = {
+  accountNumber:    true,
+  billingAddress:   true,
+  loanNumber:       true,
+  residenceAddress: true
+};
+
+var _studentLoanOptions = {
+  accountNumber: true,
+  billingAddress: true,
+  loanNumber: true,
+  ssn: true
+};
+
+var _vehicleLoanOptions = {
+  accountNumber: true,
+  loanNumber: true
+};
+
+var _consumerLoanOptions = {
+  accountNumber: true,
+  transactionNumber: true
+};
+
+var _cardOptions = {
+  accountNumber: true,
+  cardNumber: true
+};
+
+var _checkingOptions = {
+  accountNumber: true,
+  billingAddress: true
+};
+
+var _moneyTransOptions = {
+  accountNumber: true,
+  transactionNumber: true
+};
+
+var _debtSettlementOptions = {
+  accountNumber: true,
+  billingAddress: true
+};
+
+var _creditReportingOptions = {
+  accountNumber: true,
+  residenceDob: true,
+  ssn: true
+};
+
+var _creditRepairingOptions = {
+  accountNumber: true,
+  billingAddress: true
+};
+
+var _debtOptions = {
+  accountNumber: true,
+  phoneNumber: true,
+  loanNumber: true,
+  lastSsn: true
+};
 
 function init() {
   companiesAutocomplete.init();
@@ -26,10 +90,12 @@ function init() {
   } );
 
   // Show/hide sections of Company Info.
-  var _additionalCompanyProduct;
   $( 'fieldset.additional-company' ).hide();
 
-  $( '.add-company-yes' ).on( 'change', function(){
+  $( '.add-company-yes' ).on( 'change', function() {
+    $( '#additional-consumer-identity2' ).hide();
+    $( '#additional-consumer-identity3' ).hide();
+
     if ( $( '.add-company-yes' ).is( ':checked' ) ) {
       $( 'fieldset.additional-company' ).slideDown( 400 );
       // Hide company name initially.
@@ -38,70 +104,115 @@ function init() {
       $( '#additional-consumer-identity' ).val( 'Select one...' );
 
       $( '#additional-consumer-identity' ).on( 'change', function() {
+        // Hide company name initially.
+        $( 'fieldset.additional-company.company-name-fieldset-3' ).hide();
+        $( '#additional-consumer-identity2' ).hide();
+        $( '#additional-consumer-identity3' ).hide();
+        $( '#additional-consumer-identity2' ).val( 'Select sub-product...' );
+        $( '#additional-consumer-identity3' ).val( 'Select sub-product...' );
+        $( '#company-type-3 .identify-product-options' ).hide();
+
         var product = document.querySelector( '#additional-consumer-identity' ).value;
-        $( '#additional-company-div .identify-product-options' ).remove();
+
+        $( '#additional-consumer-identity2' ).on( 'change', function(){
+          _showAddCompany( product );
+        } );
+        $( '#additional-consumer-identity3' ).on( 'change', function(){
+          _showAddCompany( product );
+        } );
+
         if ( product === 'Select one...' ) {
           $( 'fieldset.additional-company.company-name-fieldset-3' ).slideUp( 400 );
         } else {
-          $( 'fieldset.additional-company.company-name-fieldset-3' ).slideDown( 400 );
-          $( '#company3-forward' ).prop( 'checked', false );
-          $( '#forward-company3' ).hide();
 
-          var $productOption;
-          switch ( product ) {
-            case 'mortgage':
-              $productOption = $( '#identify-mortgage-company' ).clone();
-            break;
-
-            case 'student_loan':
-              $productOption = $( '#identify-student-loan-company' ).clone();
-            break;
-
-            case 'vehicle_loan':
-              $productOption = $( '#identify-vehicle-loan-company' ).clone();
-            break;
-
-            case 'consumer_loan':
-              $productOption = $( '#identify-storefront-services-company' ).clone();
-            break;
-
-            case 'card':
-              $productOption = $( '#identify-most-prepaids-company' ).clone();
-            break;
-
-            case 'checking':
-              $productOption = $( '#identify-checking-savings-company' ).clone();
-            break;
-
-            case 'money_trans':
-              $productOption = $( '#identify-money-transfer-company' ).clone();
-            break;
-
-            case 'credit_reporting':
-              $productOption = $( '#identify-credit-reporting-company' ).clone();
-            break;
-
-            case 'debt':
-              $productOption = $( '#identify-debt-collection-company' ).clone();
-            break;
+          if ( product === 'credit_reporting' ) {
+            $( '#additional-consumer-identity3' ).hide();
+            $( '#additional-consumer-identity2' ).show();
+          } else if ( product === 'money_trans' ) {
+            $( '#additional-consumer-identity2' ).hide();
+            $( '#additional-consumer-identity3' ).show();
+          } else {
+            _showAddCompany( product );
           }
-          $productOption.attr( 'id' , '');
-          $productOption.appendTo( $( '#additional-company-div .cr-fieldset' )[0] );
-          $productOption.find( '.identify-account' ).on( 'change', function() {
-            if ( $( '.identification-type' ).is( ':checked' ) ) {
-              internationalAddresses.initOptions( this );
-            }
-          } );
-          _additionalCompanyProduct = product;
         }
       } );
     }
   } );
 
+  function _showAddCompany( product ) {
+    $( 'fieldset.additional-company.company-name-fieldset-3' ).slideDown( 400 );
+    $( '#company3-forward' ).prop( 'checked', false );
+    $( '#forward-company3' ).hide();
+
+    var addCompSel = '#company-type-3 .identify-product-options';
+    var addCompOptions = document.querySelector( addCompSel );
+
+    var $productOption;
+
+    switch ( product ) {
+      case 'mortgage':
+        addCompOptions.innerHTML = identifyOptionsHandlebars( _mortgageOptions );
+      break;
+
+      case 'student_loan':
+        addCompOptions.innerHTML = identifyOptionsHandlebars( _studentLoanOptions );
+      break;
+
+      case 'vehicle_loan':
+        addCompOptions.innerHTML = identifyOptionsHandlebars( _vehicleLoanOptions );
+      break;
+
+      case 'consumer_loan':
+        addCompOptions.innerHTML = identifyOptionsHandlebars( _consumerLoanOptions );
+      break;
+
+      case 'card':
+        addCompOptions.innerHTML = identifyOptionsHandlebars( _cardOptions );
+      break;
+
+      case 'checking':
+        addCompOptions.innerHTML = identifyOptionsHandlebars( _checkingOptions );
+      break;
+
+      case 'money_trans':
+        var subproduct = document.querySelector( '#additional-consumer-identity3' ).value;
+        if ( subproduct === 'debt-settlement' ) {
+          addCompOptions.innerHTML = identifyOptionsHandlebars( _debtSettlementOptions );
+        } else {
+          addCompOptions.innerHTML = identifyOptionsHandlebars( _moneyTransOptions );
+        }
+      break;
+
+      case 'credit_reporting':
+        var subproduct = document.querySelector( '#additional-consumer-identity2' ).value;
+        if ( subproduct === 'credit-reporting' ) {
+          addCompOptions.innerHTML = identifyOptionsHandlebars( _creditReportingOptions );
+        } else {
+          addCompOptions.innerHTML = identifyOptionsHandlebars( _creditRepairingOptions );
+        }
+      break;
+
+      case 'debt':
+        addCompOptions.innerHTML = identifyOptionsHandlebars( _debtOptions );
+      break;
+    }
+
+    _initOptionDetails( addCompOptions );
+  }
+
+  function _initOptionDetails( elem ) {
+    $( elem ).hide();
+    $( elem ).find( '.identify-account' ).on( 'change', function() {
+      if ( $( '.identification-type' ).is( ':checked' ) ) {
+        internationalAddresses.initOptions( this );
+      }
+    } );
+  }
+
   $( '.add-company-no' ).on( 'change', function(){
     if ( $( '.add-company-no' ).is( ':checked' ) ) {
       $( 'fieldset.additional-company' ).slideUp( 400 );
-      $( '#additional-company-div .identify-product-options' ).slideUp( 400 );
+      $( '#company-type-3 .identify-product-options' ).slideUp( 400 );
     }
   } );
 
@@ -114,20 +225,20 @@ function init() {
   $( '#company2-forward' ).on( 'change', function() {
     if ( $( '#company2-forward' ).is( ':checked' ) ) {
       $( '#forward-company2' ).slideDown( 400 );
-      $( '#identify-credit-reporting-company' ).slideDown( 400 );
+      $( '#company-type-2 .identify-product-options' ).slideDown( 400 );
     } else {
       $( '#forward-company2' ).slideUp( 400 );
-      $( '#identify-credit-reporting-company' ).slideUp( 400 );
+      $( '#company-type-2 .identify-product-options' ).slideUp( 400 );
     }
   } );
 
   $( '#company3-forward' ).on( 'change', function() {
     if ( $( '#company3-forward' ).is( ':checked' ) ) {
       $( '#forward-company3' ).slideDown( 400 );
-      $( '#additional-company-div .identify-product-options' ).slideDown( 400 );
+      $( '#company-type-3 .identify-product-options' ).slideDown( 400 );
     } else {
       $( '#forward-company3' ).slideUp(400);
-      $( '#additional-company-div .identify-product-options' ).slideUp( 400 );
+      $( '#company-type-3 .identify-product-options' ).slideUp( 400 );
     }
   } );
 
@@ -141,152 +252,127 @@ function init() {
       var subproduct = webStorageProxy.getItem( 'subproduct_selected', localStorage );
       var issue = webStorageProxy.getItem( 'issue_selected', localStorage );
 
+      var comp1Sel = '#company-type-1 .identify-product-options';
+      var comp1Options = document.querySelector( comp1Sel );
+
+      var comp2Sel = '#company-type-2 .identify-product-options';
+      var comp2Options = document.querySelector( comp2Sel );
+
+      $( '#company-type-1 .identify-product-options' ).hide();
       $( '#company-type-2' ).hide();
+      $( '#company-type-2 .identify-product-options' ).hide();
 
-      /* alert(product + ', ' + subproduct + ', ' + issue); */
-      switch ( product ) {
-        case 'mortgage':
-          $( '#company-intro-1' ).text( 'Mortgage company' );
-          $( '#company-type-1' ).show();
-          $( '#identify-mortgage-company' ).appendTo( '#company-type-1' );
-          break;
+      if ( product === 'mortgage' ) {
+        $( '#company-intro-1' ).text( 'Mortgage company' );
+        $( '#company-type-1' ).show();
+        comp1Options.innerHTML = identifyOptionsHandlebars( _mortgageOptions );
 
-        case 'student_loan':
-          $( '#company-intro-1' ).text( 'Student loan company' );
-          $( '#company-type-1' ).show();
-          $( '#identify-student-loan-company' ).appendTo( '#company-type-1' );
-          break;
-
-        case 'vehicle_loan':
-          $( '#company-intro-1' ).text( 'Vehicle loan company' );
-          $( '#company-type-1' ).show();
-          $( '#identify-vehicle-loan-company' ).appendTo( '#company-type-1' );
-          break;
-
-        case 'consumer_loan':
-          $( '#company-intro-1' ).text( 'Company information' );
-          $( '#company-type-1' ).show();
-          $( '#identify-storefront-services-company' ).appendTo( '#company-type-1' );
-          break;
-
-        case 'card':
-          $( '#company-intro-1' ).text( 'Card information' );
-          $( '#company-type-1' ).show();
-          $( '#identify-most-prepaids-company' ).appendTo( '#company-type-1' );
-          break;
-
-        case 'checking':
-          $( '#company-intro-1' ).text( 'Bank information' );
-          $( '#company-type-1' ).show();
-          $( '#identify-checking-savings-company' ).appendTo( '#company-type-1' );
-          break;
-
-        case 'money_trans':
-          $( '#company-intro-1' ).text( 'Company information' );
-          $( '#company-type-1' ).show();
-          $( '#identify-money-transfer-company' ).appendTo( '#company-type-1' );
-          break;
-
-        case 'credit_reporting':
+        if ( issue === 'debt_collection' ) {
+          $( '#company-intro-2' ).text( 'Debt collection company' );
+          $( '#company-type-2' ).show();
+          comp2Options.innerHTML = identifyOptionsHandlebars( _debtOptions );
+        }
+      } else if ( product === 'credit_reporting' ) {
+        if ( subproduct === 'credit-reporting' ) {
           $( '#company-intro-1' ).text( 'Credit reporting company' );
           $( '#company-type-1' ).show();
-          $( '#identify-credit-reporting-company' ).appendTo( '#company-type-1' );
-          break;
-
-        case 'debt':
-          $( '#company-intro-1' ).text( 'Debt collection company' );
-          $( '#company-type-1' ).show();
-          $( '#company-type-2' ).show();
-          $( '#identify-debt-collection-company' ).appendTo( '#company-type-1' );
-          break;
-
-        default:
-          $( '#company-intro-1' ).text( 'Company information' );
-          $( '#company-type-1' ).show();
-      }
-
-      switch ( subproduct ) {
-        case 'credit-repair':
+          comp1Options.innerHTML = identifyOptionsHandlebars( _creditReportingOptions );
+        } else if ( subproduct === 'credit-repair' ) {
           $( '#company-intro-1' ).text( 'Credit repair company' );
           $( '#company-type-1' ).show();
-          $( '#identify-credit-reporting-company' ).remove();
-          $( '#identify-credit-debt-repair-company' ).appendTo( '#company-type-1' );
-          break;
-
-        case 'debt-settlement':
-          $( '#company-intro-1' ).text( 'Debt settlement company' );
-          $( '#company-type-1' ).show();
-          $( '#identify-money-transfer-company' ).remove();
-          $( '#identify-credit-debt-repair-company' ).appendTo( '#company-type-1' );
-          break;
-
-        case 'domestic-money-transfer':
-          $( '#company-intro-1' ).text( 'Money transfer company' );
-          $( '#company-type-1' ).show();
-          break;
-
-        case 'international-money-transfer':
-          $( '#company-intro-1' ).text( 'Money transfer company' );
-          $( '#company-type-1' ).show();
-          break;
-
-        case 'foreign-currency-exchange':
-          $( '#company-intro-1' ).text( 'Currency exchange company' );
-          $( '#company-type-1' ).show();
-          $( '#identify-credit-reporting-company' ).remove();
-          $( '#identify-storefront-services-company' ).appendTo( '#company-type-1' );
-
-        // Debt collection subproducts.
-        case 'credit-card-debt-collection':
-          $( '#company-intro-2' ).text( 'Credit card company' );
-          break;
-
-        case 'mortgage-debt-collection':
-          $( '#company-intro-2' ).text( 'Mortgage company' );
-          break;
-
-        case 'medical-debt-collection':
-          $( '#company-intro-2' ).text( 'Medical company' );
-          break;
-
-        case 'payday-loan-debt-collection':
-          $( '#company-intro-2' ).text( 'Payday loan company' );
-          break;
-
-        case 'auto-debt-collection':
-          $( '#company-intro-2' ).text( 'Auto company' );
-          break;
-
-        case 'federal-student-debt-collection':
-          $( '#company-intro-2' ).text( 'Federal student loan company' );
-          break;
-
-        case 'non-federal-student-debt-collection':
-          $( '#company-intro-2' ).text( 'Non-federal student loan company' );
-          break;
-
-        case 'other-debt-collection':
-          $( '#company-intro-2' ).text( 'Other debt company' );
-          break;
-
-        case 'unknown-debt-collection':
-          $( '#company-intro-2' ).text( 'Unknown company' );
-          break;
-      }
-
-      switch ( issue ) {
-        case 'credit_reporting':
-          $( '#company-intro-2' ).text( 'Credit reporting company' );
+          comp1Options.innerHTML = identifyOptionsHandlebars( _creditRepairingOptions );
+        }
+      } else if ( product === 'card' ) {
+        $( '#company-intro-1' ).text( 'Company information' );
+        $( '#company-type-1' ).show();
+          comp1Options.innerHTML = identifyOptionsHandlebars( _cardOptions );
+        if ( subproduct === 'credit-card' && issue === 'debt_collection' ) {
+          $( '#company-intro-2' ).text( 'Debt collection company' );
           $( '#company-type-2' ).show();
-          $( '#identify-credit-reporting-company' ).appendTo( '#company-type-2' );
-          break;
+          comp2Options.innerHTML = identifyOptionsHandlebars( _debtOptions );
+        }
+      } else if ( product === 'checking' ) {
+        $( '#company-intro-1' ).text( 'Company information' );
+        $( '#company-type-1' ).show();
+        comp1Options.innerHTML = identifyOptionsHandlebars( _checkingOptions );
+        if ( issue === 'debt_collection' ) {
+          $( '#company-intro-2' ).text( 'Debt collection company' );
+          $( '#company-type-2' ).show();
+          comp2Options.innerHTML = identifyOptionsHandlebars( _debtOptions );
+        }
+      } else if ( product === 'vehicle_loan' ) {
+        $( '#company-intro-1' ).text( 'Vehicle loan company' );
+        $( '#company-type-1' ).show();
+        comp1Options.innerHTML = identifyOptionsHandlebars( _vehicleLoanOptions );
+        if ( issue === 'debt_collection' ) {
+          $( '#company-intro-2' ).text( 'Debt collection company' );
+          $( '#company-type-2' ).show();
+          comp2Options.innerHTML = identifyOptionsHandlebars( _debtOptions );
+        }
+      } else if ( product === 'student_loan' ) {
+        $( '#company-intro-1' ).text( 'Student loan company' );
+        $( '#company-type-1' ).show();
+        comp1Options.innerHTML = identifyOptionsHandlebars( _studentLoanOptions );
+        if ( issue === 'debt_collection' ) {
+          $( '#company-intro-2' ).text( 'Debt collection company' );
+          $( '#company-type-2' ).show();
+          comp2Options.innerHTML = identifyOptionsHandlebars( _debtOptions );
+        }
+      } else if ( product === 'consumer_loan' ) {
+        $( '#company-intro-1' ).text( 'Company information' );
+        $( '#company-type-1' ).show();
+        comp1Options.innerHTML = identifyOptionsHandlebars( _consumerLoanOptions );
+        if ( issue === 'debt_collection' ) {
+          $( '#company-intro-2' ).text( 'Debt collection company' );
+          $( '#company-type-2' ).show();
+          comp2Options.innerHTML = identifyOptionsHandlebars( _debtOptions );
+        }
+      } else if ( product === 'money_trans' ) {
+        $( '#company-intro-1' ).text( 'Company information' );
+        $( '#company-type-1' ).show();
+        comp1Options.innerHTML = identifyOptionsHandlebars( _moneyTransOptions );
+        if ( subproduct === 'debt-settlement' ) {
+          comp1Options.innerHTML = identifyOptionsHandlebars( _debtSettlementOptions );
+        }
+      } else if ( product === 'debt' ) {
+        $( '#company-intro-1' ).text( 'Debt collection company' );
+        $( '#company-type-1' ).show();
+        comp1Options.innerHTML = identifyOptionsHandlebars( _debtOptions );
+        if ( subproduct === 'mortgage-debt-collection' ) {
+          $( '#company-intro-2' ).text( 'Mortgage company' );
+          $( '#company-type-2' ).show();
+          comp2Options.innerHTML = identifyOptionsHandlebars( _mortgageOptions );
+        } else if ( subproduct === 'credit-card-debt-collection' ) {
+          $( '#company-intro-2' ).text( 'Credit card company' );
+          $( '#company-type-2' ).show();
+          comp2Options.innerHTML = identifyOptionsHandlebars( _cardOptions );
+        } else if ( subproduct === 'medical-debt-collection' ) {
+          $( '#company-intro-2' ).text( 'Company information' );
+          $( '#company-type-2' ).show();
+        } else if ( subproduct === 'payday-loan-debt-collection' ) {
+          $( '#company-intro-2' ).text( 'Payday company' );
+          $( '#company-type-2' ).show();
+          comp2Options.innerHTML = identifyOptionsHandlebars( _consumerLoanOptions );
+        } else if ( subproduct === 'auto-debt-collection' ) {
+          $( '#company-intro-2' ).text( 'Vehicle loan company' );
+          $( '#company-type-2' ).show();
+          comp2Options.innerHTML = identifyOptionsHandlebars( _vehicleLoanOptions );
+        } else if ( subproduct === 'federal-student-debt-collection' ) {
+          $( '#company-intro-2' ).text( 'Student loan company' );
+          $( '#company-type-2' ).show();
+          comp2Options.innerHTML = identifyOptionsHandlebars( _studentLoanOptions );
+        } else if ( subproduct === 'non-federal-student-debt-collection' ) {
+          $( '#company-intro-2' ).text( 'Student loan company' );
+          $( '#company-type-2' ).show();
+          comp2Options.innerHTML = identifyOptionsHandlebars( _studentLoanOptions );
+        } else if ( subproduct === 'other-debt-collection' ) {
+          $( '#company-intro-2' ).text( 'Other company information' );
+          $( '#company-type-2' ).show();
+        }
       }
 
-      /*
-      if ( $( '.company-name-input' ).val()) {
-      $(this).closest( '.identify-product-options' ).slideDown(200);
-      }
-      */
+      _initOptionDetails( comp1Options );
+      _initOptionDetails( comp2Options );
     }, 11 );
   }
   /*         var announceissue = localStorage.getItem("issue_selected").text()); */

--- a/src/static/tmpl/identify-mortgage-company.handlebars
+++ b/src/static/tmpl/identify-mortgage-company.handlebars
@@ -1,0 +1,36 @@
+<fieldset class="cr-fieldset identify-product-options">
+
+    <div class="row cr-question">
+        <div class="span3 cr-label">
+            <label>
+                How should this company identify you?
+                <div class='is-required'>Required</div>
+            </label>
+
+        </div>
+
+        <div class="span9 cr-answer cr-radios cr-behalf prodselect">
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type loan-number' name="identify-account" value="loan-number">
+                Loan number
+            </label>
+
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
+                Account number
+            </label>
+
+            <label class="radio block last">
+                <input type="radio" class='identify-account identification-type residence-address' name="identify-account" value="residence-address">
+                Residence address
+            </label>
+
+            <label class="radio block last">
+                <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
+                Billing address
+            </label>
+
+        </div>
+    </div>
+
+</fieldset>

--- a/src/static/tmpl/identify-options.handlebars
+++ b/src/static/tmpl/identify-options.handlebars
@@ -1,0 +1,118 @@
+<fieldset id="identify-mortgage-company" class="cr-fieldset identify-product-options">
+
+    {{#if phoneNumber }}
+    <div class="row cr-question">
+        <div class="span3 cr-label cr-question-left identify-debt-collection-company-phone">
+            <label for="company-account">
+                What phone number has been receiving calls from this debt collector?
+            </label>
+            <input type="text"
+                   name="company-account"
+                   id="company-account"
+                   class="accountinput"
+                   placeholder="">
+        </div>
+    </div>
+    {{/if}}
+
+    <div class="row cr-question">
+        <div class="span3 cr-label">
+            <label>
+                How should this company identify you?
+                <div class='is-required'>Required</div>
+            </label>
+
+        </div>
+
+        <div class="span9 cr-answer cr-radios cr-behalf prodselect">
+            {{#if accountNumber }}
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type account-number' name="identify-account" value="account-number">
+                Account number
+            </label>
+            {{/if}}
+
+            {{#if residenceDob }}
+            <label class="radio block last">
+                <input type="radio"
+                       class="identify-account
+                              identification-type
+                              address-dob"
+                       name="identify-account"
+                       value="address-dob">
+                Residence address + Date of birth
+            </label>
+            {{/if}}
+
+            {{#if billingAddress }}
+            <label class="radio block last">
+                <input type="radio" class='identify-account identification-type billing-address' name="identify-account" value="billing-address">
+                Billing address
+            </label>
+            {{/if}}
+
+            {{#if loanNumber }}
+            <label class="radio block">
+                <input type="radio" class='identify-account identification-type loan-number' name="identify-account" value="loan-number">
+                Loan number
+            </label>
+            {{/if}}
+
+            {{#if lastSsn }}
+            <label class="radio block last">
+                <input type="radio"
+                       class="identify-account
+                              identification-type
+                              social-security-last-four"
+                       name="identify-account"
+                       value="social-security-last-four">
+                Last four digits of Social Security Number
+            </label>
+            {{/if}}
+
+            {{#if residenceAddress }}
+            <label class="radio block last">
+                <input type="radio" class='identify-account identification-type residence-address' name="identify-account" value="residence-address">
+                Residence address
+            </label>
+            {{/if}}
+
+            {{#if ssn }}
+            <label class="radio block last">
+                <input type="radio"
+                       class='identify-account
+                             identification-type
+                             social-security-number'
+                       name="identify-account"
+                       value="social-security-number">
+                Social security number
+            </label>
+            {{/if}}
+
+            {{#if cardNumber }}
+            <label class="radio block">
+                <input type="radio"
+                       class="identify-account
+                              identification-type
+                              card-number"
+                       name="identify-account"
+                       value="card-number">
+                Card number
+            </label>
+            {{/if}}
+
+            {{#if transactionNumber }}
+            <label class="radio block">
+                <input type="radio"
+                       class="identify-account
+                              identification-type
+                              transaction-number"
+                       name="identify-account"
+                       value="transaction-number">
+                Transaction number
+            </label>
+            {{/if}}
+        </div>
+    </div>
+
+</fieldset>

--- a/src/v0/form/css/complain.css
+++ b/src/v0/form/css/complain.css
@@ -2208,6 +2208,10 @@ a.annotation-button:hover,
     margin-left: 10px;
 }
 
+#bd1 {
+    margin-left: 18px;
+}
+
 #ssn3,
 #bd3 {
     width: 57px;
@@ -2227,4 +2231,9 @@ a.annotation-button:hover,
 #affiliations {
     border-top: dotted 1px #ccc;
     padding-top: 12px;
+}
+
+#additional-consumer-identity2,
+#additional-consumer-identity3 {
+    clear: none;
 }


### PR DESCRIPTION
## Changes

- Made "how should this company identify you" section a template.
- Updated product option ("how should this company identify you") combinations.
- Updated company name selection to handle proper state when removing name.
- Adjusts margin of date of birth input to align it with other fields.

## Testing

- `gulp clean && gulp build`
- select a product and subproduct on step 1.
- on step 4 try any combination of: 
  - entering an existing company name.
  - entering a non-existing company name.
  - deleting the entered company name.
  - checking/unchecking "This company should also receive and respond to this complaint."
- Also on step 4, click "Yes" for "Additional company":
  - Select "Credit reporting"
  - Select either subproduct option.
  - Company name should not show up till subproduct is selected. 
  - Try same thing with "Money transfer …" and "Debt settlement"

## Review

- @niqjohnson 

## Screenshots

![screen shot 2016-07-14 at 10 21 21 am](https://cloud.githubusercontent.com/assets/704760/16842826/d923df04-49ac-11e6-8969-0bb9b5172b52.png)
