### PR TITLE
Step 4, debt/credit reporting company on top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 - Nothing.
 
 ### Changed
-- Nothing.
+- Changed behavior for select a company step so that debt/credit reporting
+  company is always on top and second company is hidden behind a toggle.
 
 ### Deprecated
 - Nothing.

--- a/src/company-information.html
+++ b/src/company-information.html
@@ -155,6 +155,12 @@ COMPANY-1
 
     <h3 id="company-intro-1" class="company-intro">Company information</h3>
 
+    <p id="company-type-1-intro-text" class="page-intro select-product extra-bottom">
+        Based on the issue selected, it appears the complaint actually has to do with a
+        <span id="company-type-1-product">[product]</span>,
+        not a <span id="company-type-1-subproduct">[subproduct]</span>.
+    </p>
+
     <fieldset id="company-name-fieldset-1" class="cr-fieldset">
         <!-- question -->
         <div class="row cr-question">
@@ -277,9 +283,28 @@ End company-1
 COMPANY-2
 ///////////
 -->
-<!-- this was an easy fix for spacing-->
 
-<!-- end easy -->
+<!-- Start company 2 question -->
+<div id="company-type-2-option">
+
+    <h3 id="company-type-2-option_header" for="select_subproduct" class="last product subproduct_label product_vehicle_loan label_same_as_header" style="display: block;">
+        Do you think your complaint involves the [mortgage company]?
+    </h3>
+    <div class="span9 cr-answer cr-radios cr-behalf prodselect">
+        <label class="radio block">
+            <input type="radio" class="second-company-yes" name="add-company" value="yes">
+            Yes
+        </label>
+
+        <label class="radio block last">
+            <input type="radio" class="second-company-no" name="add-company" value="no">
+            No
+        </label>
+    </div>
+
+</div>
+
+<!-- Start company 2 input -->
 
 <div id="company-type-2" class="company-type">
 

--- a/src/static/js/modules/step-company-information.js
+++ b/src/static/js/modules/step-company-information.js
@@ -89,6 +89,21 @@ function init() {
     }
   } );
 
+  $( '#company-type-2-option' ).hide();
+
+  // Whether to show/hide the second company.
+  $( '.second-company-yes' ).on( 'change', function() {
+    if ( $( '.second-company-yes' ).is( ':checked' ) ) {
+      $( '#company-type-2' ).slideDown();
+    }
+  } );
+
+  $( '.second-company-no' ).on( 'change', function() {
+    if ( $( '.second-company-no' ).is( ':checked' ) ) {
+      $( '#company-type-2' ).slideUp();
+    }
+  } );
+
   // Show/hide sections of Company Info.
   $( 'fieldset.additional-company' ).hide();
 
@@ -242,6 +257,98 @@ function init() {
     }
   } );
 
+  function _getSubproduct( subproduct ) {
+    var subProductQ = '';
+    switch ( subproduct ) {
+      case 'payday-loan':
+        subProductQ = 'Payday loan';
+        break;
+      case 'pawn-loan':
+        subProductQ = 'Pawn loan';
+        break;
+      case 'title-loan':
+        subProductQ = 'Title loan';
+        break;
+      case 'installment-loan':
+        subProductQ = 'Installment loan';
+        break;
+      case 'personal-line-of-credit':
+        subProductQ = 'Personal line of credit';
+        break;
+      case 'checking-account':
+        subProductQ = 'Checking account';
+        break;
+      case 'savings-account':
+        subProductQ = 'Savings account';
+        break;
+      case 'certificate-of-deposit':
+        subProductQ = 'Certificate of deposit';
+        break;
+      case 'other-bank-product-or-service':
+        subProductQ = 'Other bank product or service';
+        break;
+    }
+
+    return subProductQ;
+  }
+
+  function _showSecondCompanyQuestion( product, subproduct, issue ) {
+    var comp1Sel = '#company-type-1 .identify-product-options';
+    var comp1Options = document.querySelector( comp1Sel );
+
+    var comp2Sel = '#company-type-2 .identify-product-options';
+    var comp2Options = document.querySelector( comp2Sel );
+
+    var secondCompanyTitle = '';
+    var secondCompanyOptions = {};
+    switch ( product ) {
+      case 'mortgage':
+        secondCompanyTitle = 'Mortgage company';
+        secondCompanyOptions = _mortgageOptions;
+        break;
+      case 'consumer_loan':
+        secondCompanyTitle = _getSubproduct( subproduct );
+        secondCompanyOptions = _consumerLoanOptions;
+        break;
+      case 'student_loan':
+        secondCompanyTitle = 'Student loan company';
+        secondCompanyOptions = _studentLoanOptions;
+        break;
+      case 'vehicle_loan':
+        secondCompanyTitle = 'Vehicle loan company';
+        secondCompanyOptions = _vehicleLoanOptions;
+        break;
+      case 'card':
+        secondCompanyTitle = 'Credit card company';
+        secondCompanyOptions = _cardOptions;
+        break;
+      case 'checking':
+        secondCompanyTitle = _getSubproduct( subproduct );
+        secondCompanyOptions = _checkingOptions;
+        break;
+    }
+
+    if ( issue === 'debt_collection' ) {
+      $( '#company-intro-1' ).text( 'Debt collection company' );
+      $( '#company-type-1-product' ).text( 'debt collection company' );
+    } else if ( issue === 'credit_reporting' ) {
+      $( '#company-intro-1' ).text( 'Credit reporting company' );
+      $( '#company-type-1-product' ).text( 'credit reporting company' );
+   }
+
+    $( '#company-type-1' ).show();
+    $( '#company-type-2-option_header' ).text( 'Does the complaint also involve the ' + secondCompanyTitle.toLowerCase() + '?' );
+    $( '#company-intro-2' ).text( secondCompanyTitle );
+    $( '.company-2-checkbox' ).hide();
+    $( '.company-2-checkbox input' ).prop( 'checked', true );
+    $( '#forward-company2' ).show();
+    $( '#company-type-2-option' ).show();
+    comp1Options.innerHTML = identifyOptionsHandlebars( _debtOptions );
+    comp2Options.innerHTML = identifyOptionsHandlebars( secondCompanyOptions );
+    $( '#company-type-1-subproduct' ).text( secondCompanyTitle.toLowerCase() );
+    $( '#company-type-1-intro-text' ).show();
+  }
+
   // Show/hide product identification options.
   $( 'fieldset.identify-options' ).hide();
   $( '.company_verification_fieldset' ).hide();
@@ -259,18 +366,17 @@ function init() {
       var comp2Options = document.querySelector( comp2Sel );
 
       $( '#company-type-1 .identify-product-options' ).hide();
+      $( '#company-type-1-intro-text' ).hide();
       $( '#company-type-2' ).hide();
       $( '#company-type-2 .identify-product-options' ).hide();
+      $( '.company-2-checkbox' ).show();
 
       if ( product === 'mortgage' ) {
         $( '#company-intro-1' ).text( 'Mortgage company' );
         $( '#company-type-1' ).show();
         comp1Options.innerHTML = identifyOptionsHandlebars( _mortgageOptions );
-
-        if ( issue === 'debt_collection' ) {
-          $( '#company-intro-2' ).text( 'Debt collection company' );
-          $( '#company-type-2' ).show();
-          comp2Options.innerHTML = identifyOptionsHandlebars( _debtOptions );
+        if ( issue === 'debt_collection' || issue === 'credit_reporting' ) {
+          _showSecondCompanyQuestion( product, subproduct, issue );
         }
       } else if ( product === 'credit_reporting' ) {
         if ( subproduct === 'credit-reporting' ) {
@@ -285,47 +391,38 @@ function init() {
       } else if ( product === 'card' ) {
         $( '#company-intro-1' ).text( 'Company information' );
         $( '#company-type-1' ).show();
-          comp1Options.innerHTML = identifyOptionsHandlebars( _cardOptions );
-        if ( subproduct === 'credit-card' && issue === 'debt_collection' ) {
-          $( '#company-intro-2' ).text( 'Debt collection company' );
-          $( '#company-type-2' ).show();
-          comp2Options.innerHTML = identifyOptionsHandlebars( _debtOptions );
+        comp1Options.innerHTML = identifyOptionsHandlebars( _cardOptions );
+        if ( subproduct === 'credit-card' &&
+             ( issue === 'debt_collection' || issue === 'credit_reporting' ) ) {
+          _showSecondCompanyQuestion( product, subproduct, issue );
         }
       } else if ( product === 'checking' ) {
         $( '#company-intro-1' ).text( 'Company information' );
         $( '#company-type-1' ).show();
         comp1Options.innerHTML = identifyOptionsHandlebars( _checkingOptions );
-        if ( issue === 'debt_collection' ) {
-          $( '#company-intro-2' ).text( 'Debt collection company' );
-          $( '#company-type-2' ).show();
-          comp2Options.innerHTML = identifyOptionsHandlebars( _debtOptions );
+        if ( issue === 'debt_collection' || issue === 'credit_reporting' ) {
+          _showSecondCompanyQuestion( product, subproduct, issue );
         }
       } else if ( product === 'vehicle_loan' ) {
         $( '#company-intro-1' ).text( 'Vehicle loan company' );
         $( '#company-type-1' ).show();
         comp1Options.innerHTML = identifyOptionsHandlebars( _vehicleLoanOptions );
-        if ( issue === 'debt_collection' ) {
-          $( '#company-intro-2' ).text( 'Debt collection company' );
-          $( '#company-type-2' ).show();
-          comp2Options.innerHTML = identifyOptionsHandlebars( _debtOptions );
+        if ( issue === 'debt_collection' || issue === 'credit_reporting' ) {
+          _showSecondCompanyQuestion( product, subproduct, issue );
         }
       } else if ( product === 'student_loan' ) {
         $( '#company-intro-1' ).text( 'Student loan company' );
         $( '#company-type-1' ).show();
         comp1Options.innerHTML = identifyOptionsHandlebars( _studentLoanOptions );
-        if ( issue === 'debt_collection' ) {
-          $( '#company-intro-2' ).text( 'Debt collection company' );
-          $( '#company-type-2' ).show();
-          comp2Options.innerHTML = identifyOptionsHandlebars( _debtOptions );
+        if ( issue === 'debt_collection' || issue === 'credit_reporting' ) {
+          _showSecondCompanyQuestion( product, subproduct, issue );
         }
       } else if ( product === 'consumer_loan' ) {
         $( '#company-intro-1' ).text( 'Company information' );
         $( '#company-type-1' ).show();
         comp1Options.innerHTML = identifyOptionsHandlebars( _consumerLoanOptions );
-        if ( issue === 'debt_collection' ) {
-          $( '#company-intro-2' ).text( 'Debt collection company' );
-          $( '#company-type-2' ).show();
-          comp2Options.innerHTML = identifyOptionsHandlebars( _debtOptions );
+        if ( issue === 'debt_collection' || issue === 'credit_reporting' ) {
+          _showSecondCompanyQuestion( product, subproduct, issue );
         }
       } else if ( product === 'money_trans' ) {
         $( '#company-intro-1' ).text( 'Company information' );

--- a/src/v0/form/css/complain.css
+++ b/src/v0/form/css/complain.css
@@ -2237,3 +2237,7 @@ a.annotation-button:hover,
 #additional-consumer-identity3 {
     clear: none;
 }
+
+#company-type-2-option .prodselect {
+    margin-left: 0;
+}


### PR DESCRIPTION
## Changes

- Changed behavior for select a company step so that debt/credit reporting company is always on top and second company is hidden behind a toggle.

## Testing

- `gulp clean && gulp build`
- On step 1, select `Debt collection` product and any subproduct.
  - Step 4 should show debt collection company and second company info.
- On step 1, select `Mortage`, `Student Loan`, `Vehicle Loan or Lease`, product and any subproduct.
  - On step 2, select `Problems with a debt collector` or `Problems with my credit report or score`. 
  - Step 4 should show debt collection company or credit reporting company first and a toggle to show the second company, with a header that says "company" at the end.
- On step 1, select any `Checking or savings account`, `Payday, store, or other loan` subproduct, or only the `Credit card or prepaid card` > `Credit card` subproduct.
  - On step 2, select `Problems with a debt collector` or `Problems with my credit report or score`. 
  - Step 4 should show debt collection company or credit reporting company first and a toggle to show the second company, with a header that does not say "company" at the end (it only have the subproduct name).

## Review

- @niqjohnson 
- @kurzn 

## Screenshots

Debt collection product:
![screen shot 2016-07-25 at 9 07 04 am](https://cloud.githubusercontent.com/assets/704760/17102367/3ef8c69e-5247-11e6-9497-70c979575687.png)

Other product where "company" makes grammatical sense:
![screen shot 2016-07-25 at 9 08 20 am](https://cloud.githubusercontent.com/assets/704760/17102397/63fb9c78-5247-11e6-97fc-0aa05acb8c64.png)

Other product where "company" does not make grammatical sense:
![screen shot 2016-07-25 at 9 06 24 am](https://cloud.githubusercontent.com/assets/704760/17102412/7607e2b4-5247-11e6-82c5-cbc12487ecb6.png)

![screen shot 2016-07-25 at 9 06 46 am](https://cloud.githubusercontent.com/assets/704760/17102413/7608ebaa-5247-11e6-8d55-d61d10fca827.png)
