### PR TITLE
Fix CSS columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Nothing.
 
 ### Fixed
-- Nothing.
+- Fixed CSS columns to work around recent Chrome bugs.
 
 
 ## [0.12.1](https://cfpb.github.io/complaint-intake/versions/0.12.1/)

--- a/src/select-product.html
+++ b/src/select-product.html
@@ -307,7 +307,7 @@ What type of credit reporting product?
 
 <div id="student_loan_products" class="subproduct_sect student_loan_products">
 
-  <label id="federal-student-loan" class="radio block" data-issues="student_loan">
+  <label id="federal-student-loan" class="radio block u-mt0 u-mb0" data-issues="student_loan">
     <input name="sec_selex" type="radio" class="radio_input_subpro"/>
     Federal student loan
     <br /><small>Stafford, Direct Subsidized, Direct Unsubsidized, consolidation, PLUS, Perkins, Federal Family Education Loan (FFEL)</small>

--- a/src/v0/form/css/complain.css
+++ b/src/v0/form/css/complain.css
@@ -1414,24 +1414,9 @@ hr.pull-up {
 .issueselect label.block,
 #payday_questions_options label.block,
 #resolution_options label.block,
+.select-save-method label.block,
 .cr-radios label {
-    display: inline-block;
-    position: relative;
-    background: #dee0e2;
-    width: 100%;
-    border: 2px solid #dee0e2;
-    padding: 18px 30px 15px 45px;
-    margin-bottom: 4px;
-    margin-right: 4px;
-    cursor: pointer;
-}
-
-.prodselect label.block,
-.issueselect label.block,
-#payday_questions_options label.block,
-#resolution_options label.block,
-.select-save-method label.block {
-    display: inline-block;
+    display: block;
     position: relative;
     background: #dee0e2;
     width: 100%;
@@ -1440,15 +1425,35 @@ hr.pull-up {
     margin-bottom: 4px;
     margin-right: 4px;
     cursor: pointer;
-/*
--webkit-column-break-inside:avoid;
--moz-column-break-inside:avoid;
--o-column-break-inside:avoid;
--ms-column-break-inside:avoid;
-column-break-inside:avoid;
-*/
-    -webkit-margin-before: 2px;
-    -webkit-margin-after: 2px;
+    -webkit-column-break-inside: avoid;
+    -moz-column-break-inside: avoid;
+    -o-column-break-inside: avoid;
+    -ms-column-break-inside: avoid;
+    page-break-inside: avoid;
+    break-inside: avoid-column;
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.select-product-or-issue label:nth-child(2n + 1),
+.prodselect label.block:nth-child(2n + 1),
+.issueselect label.block:nth-child(2n + 1),
+#payday_questions_options label.block:nth-child(2n + 1),
+#resolution_options label.block:nth-child(2n + 1),
+.select-save-method label.block:nth-child(2n + 1),
+.cr-radios label {
+    margin-top: 4px;
+    margin-bottom: 4px;
+}
+
+.select-product-or-issue label:first-child,
+.prodselect label.block:first-child,
+.issueselect label.block:first-child,
+#payday_questions_options label.block:first-child,
+#resolution_options label.block:first-child,
+.select-save-method label.block:first-child,
+.cr-radios label {
+    margin-top: 4px;
 }
 /*
   @media (min-width: 641px) {

--- a/src/your-information.html
+++ b/src/your-information.html
@@ -149,12 +149,12 @@
                 </p>
 
                 <div id="select-who-involved" class="select-product-or-issue all-topissues">
-                    <label class="radio block u-mt0">
+                    <label class="radio block">
                         <input id="select-who-involved_just-me" name="radio_" type="radio" class="radio_input" />
                         Just you
                     </label>
 
-                    <label class="radio block u-mt0">
+                    <label class="radio block">
                         <input id="select-who-involved_someone-else" name="radio_" type="radio" class="radio_input" />
                         Someone else
                     </label>


### PR DESCRIPTION
A recent release of Chrome changes how CSS columns are handled, breaking some of our layouts. These changes get the form looking right again in Chrome. See GHE issue 85 for more details.

## Changes

- Changes to how CSS columns are set

## Testing

- Select "Credit card or prepaid card" as the product. The sub-product list should slide down. (Previously, selecting that product would cause Chrome to hang.)
- Select "Credit reporting" as the product. The sub-product list should be in two columns.
- Any other multi-column section should correctly slide down and the items should be pretty much aligned (see the note below for exceptions).

## Review

- @anselmbradford 

## Screenshots

Before | After
------ | -----
![two-items](https://cloud.githubusercontent.com/assets/1862695/17568445/caabd0ba-5f11-11e6-8e30-fd212e37eb9a.png) | ![two-items-after](https://cloud.githubusercontent.com/assets/1862695/17568480/ebf33d44-5f11-11e6-9ae8-7edccc36f5fb.png)


## Notes

- Some multi-column sections with an item that has a different number of lines than all the other items aren't totally lining up. For example, select "Mortgage > Home mortgage" as the product and "Problems with my credit report or score" as the issue. The four items under "Which of these is the primary problem?" don't quite line up. I think this is acceptable for the prototype for now; we might be able to get all the multi-column sections looking good with a more extensive refactor if needed.
- I have no idea how these changes look in older versions of Chrome or in IE. Seems to look fine in Safari, though.