### PR TITLE
Add small business affiliation and questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 ### Added
-- Nothing.
+- Added small business affiliation.
 
 ### Changed
 - Nothing.
@@ -10,7 +10,7 @@
 - Nothing.
 
 ### Removed
-- Nothing.
+- Removed student and disability affiliations.
 
 ### Fixed
 - Nothing.

--- a/src/static/js/modules/international-addresses.js
+++ b/src/static/js/modules/international-addresses.js
@@ -40,10 +40,12 @@ function initOptions( context ) {
 
 function _initAddress( addressDom, id ) {
   var label = addressDom.getAttribute( 'data-label' );
-  if ( label !== 'Company address' ) {
-    addressDom.innerHTML = addressHandlebars( { id: id, label: label, addOptionalText: true } );
+  if ( label !== 'Company address' && label !== 'Business address' ) {
+    addressDom.innerHTML = addressHandlebars( { id: id, label: label, addOptionalText: true, addressIsOptional: false  } );
+  } else if ( label === 'Business address' ) {
+    addressDom.innerHTML = addressHandlebars( { id: id, label: label, addOptionalText: true, addressIsOptional: true } );
   } else {
-    addressDom.innerHTML = addressHandlebars( { id: id, label: label, addOptionalText: false } );
+    addressDom.innerHTML = addressHandlebars( { id: id, label: label, addOptionalText: false, addressIsOptional: false  } );
   }
   _countryDropdownDom = addressDom.querySelector( '#address-country-' + id );
   _addressMap[_countryDropdownDom.id] = addressDom;
@@ -60,9 +62,11 @@ function _countryChanged( evt ) {
   if ( evt.target.value !== '100' ) {
     opts.isInternational = true;
   }
-
   if ( label !== 'Company address' ) {
     opts.addOptionalText = true;
+  }
+  if ( label === 'Business address' ) {
+    opts.addressIsOptional = true;
   }
   _addressContainerDom = _addressMap[evt.target.id];
   _countryDropdownDom = _addressContainerDom.querySelector( '#address-country-' + id );

--- a/src/static/js/modules/step-your-information.js
+++ b/src/static/js/modules/step-your-information.js
@@ -9,7 +9,7 @@ function init() {
 
   internationalAddresses.init();
 
-   // Show/hide military status
+  // Show/hide affiliation follow-up questions
   $( '.cr-servicemember input' ).on( 'change', function(){
     if ( $( '#cr-military-spouse' ).is( ':checked' ) ) {
       $( '#servicemember-details' ).slideDown( 400 );
@@ -27,12 +27,31 @@ function init() {
       $( '#servicemember-details1' ).slideUp( 400 );
     }
 
+    if ( $( '#cr-small-business-owner' ).is( ':checked' ) ) {
+      $( '#small-business-owner-details' ).slideDown( 400 );
+      $( '.cr-servicemember-info' ).slideUp( 300 );
+      $( '.cr-military-status hr' ).show();
+    } else {
+      $( '#small-business-owner-details' ).slideUp( 400 );
+    }
+
     if ( !$( '#cr-military-status' ).is( ':checked' ) &&
-         !$( '#cr-military-spouse' ).is( ':checked' ) ) {
+         !$( '#cr-military-spouse' ).is( ':checked' ) &&
+         !$( '#cr-small-business-owner' ).is( ':checked' ) ) {
       $( '.cr-servicemember-info, .cr-military-status' ).slideUp( 300 );
     }
   } );
   $( '.cr-military-status' ).slideUp();
+
+  // Show/hide small business follow-up questions
+  $( '#small-business-owner-details .select-product-or-issue' ).on( 'change', '.radio_input', function() {
+    var isBusinessOwner = $( this ).val();
+    if( isBusinessOwner === 'yes' ) {
+      $( '#small-business-owner-followups' ).slideDown( 400 );
+    } else {
+      $( '#small-business-owner-followups' ).slideUp( 400 );
+    }
+  });
 
   // Show/hide sections of Your Info.
   $( 'fieldset.additional-consumer' ).hide();

--- a/src/static/tmpl/address.handlebars
+++ b/src/static/tmpl/address.handlebars
@@ -1,8 +1,7 @@
 <div class="row cr-question">
     <div class="span3 cr-label cr-question-left">
         <label for="address-country-{{id}}">
-            {{label}} country
-            <small class="inline"></small>
+            {{label}} country {{#if addressIsOptional}}<small class="inline">(optional)</small>{{/if}}
         </label>
 
         <select id="address-country-{{id}}" class="filled" data-label="{{label}}">
@@ -396,7 +395,7 @@
 <div class="row cr-question">
     <div class="span3 cr-label cr-question-left">
         <label for="address-line1-{{id}}">
-            {{label}} line 1
+            {{label}} line 1 {{#if addressIsOptional}}<small class="inline">(optional)</small>{{/if}}
         </label>
         <input type="text"
                name="address-line1-{{id}}"
@@ -406,7 +405,7 @@
 <div class="row cr-question">
     <div class="span3 cr-label cr-question-left">
         <label for="address-line2-{{id}}">
-            {{label}} line 2 {{#if addOptionalText}}<small class="inline">(Optional)</small>{{/if}}
+            {{label}} line 2 {{#if addOptionalText}}<small class="inline">(optional)</small>{{/if}}
             <div class='is-required'>Answer Required</div>
         </label>
 
@@ -419,7 +418,7 @@
 <div class="row cr-question">
     <div class="span3 cr-label cr-question-left">
         <label for="address-line3-{{id}}">
-            {{label}} line 3 {{#if addOptionalText}}<small class="inline">(Optional)</small>{{/if}}
+            {{label}} line 3 {{#if addOptionalText}}<small class="inline">(optional)</small>{{/if}}
             <div class='is-required'>Answer Required</div>
         </label>
 
@@ -432,7 +431,7 @@
 <div class="row cr-question cr-question-last">
     <div class="span2 cr-label cr-question-col">
         <label for="address-city-{{id}}">
-            City
+            City {{#if addressIsOptional}}<small class="inline">(optional)</small>{{/if}}
         </label>
         <input type="text"
                name="address-city-{{id}}"
@@ -444,14 +443,12 @@
 
         {{#if isInternational}}
         <label for="address-state-{{id}}">
-            State/Province/Region
-            <small class="inline"></small>
+            State/Province/Region {{#if addressIsOptional}}<small class="inline">(optional)</small>{{/if}}
         </label>
         <input type="text" name="address-state-{{id}}" id="address-state-{{id}}" placeholder="">
         {{else}}
         <label for="address-state-{{id}}">
-            State
-            <small class="inline"></small>
+            State {{#if addressIsOptional}}<small class="inline">(optional)</small>{{/if}}
         </label>
         <select name="address-state-{{id}}" id="address-state-{{id}}">
             <option value="" disabled="disabled" selected="selected">Select a state...</option>
@@ -524,14 +521,14 @@
     <div class="span3 cr-label cr-question-col">
         {{#if isInternational}}
         <label for="address-zipcode-{{id}}">
-            ZIP/Postal code
+            ZIP/Postal code {{#if addressIsOptional}}<small class="inline">(optional)</small>{{/if}}
         </label>
         <input type="text"
                name="address-zipcode-{{id}}"
                id="address-zipcode-{{id}}">
         {{else}}
         <label for="address-zipcode-{{id}}">
-            ZIP code
+            ZIP code {{#if addressIsOptional}}<small class="inline">(optional)</small>{{/if}}
         </label>
         <input type="text"
                name="address-zipcode-{{id}}"

--- a/src/v0/form/css/complain.css
+++ b/src/v0/form/css/complain.css
@@ -1687,6 +1687,48 @@ cruxform input.company-name-input {
     padding-top: 16px;
 }
 
+/* ==========================================================================
+   Affiliation details
+   ========================================================================== */
+
+#affiliations > .prodselect {
+    box-sizing: border-box;
+    width: 100%;
+    padding-left: 18px;
+    padding-right: 18px;
+}
+
+.affiliation-details > .cr-label > label {
+    padding-top: 30px;
+    text-transform: uppercase;
+}
+
+.affiliation-section:not(:last-of-type) {
+    padding-bottom: 30px;
+    border-bottom: 1px solid #ccc;
+}
+
+#small-business-owner-details {
+    padding-top: 15px;
+}
+
+#small-business-owner-details > .span3.cr-label {
+    margin-left: 0;
+}
+
+#small-business-owner-details .select-product-or-issue.all-topissues {
+    box-sizing: border-box;
+    padding: 15px 18px 0 18px;
+}
+
+#small-business-owner-followups {
+    display: none;
+}
+
+/* ==========================================================================
+   Company autocomplete and not boarded
+   ========================================================================== */
+
 .autocomplete-suggestions { border: 1px solid #777; background: #fff; cursor: pointer; overflow: auto; }
 .autocomplete-suggestion { padding: 14px 12px; font-size: 16px; white-space: nowrap; overflow: hidden; border-bottom: dotted 1px #ccc; }
 .autocomplete-selected { background: #f0f0f0; }
@@ -1706,6 +1748,10 @@ cruxform input.company-name-input {
     width: 452px;
     overflow: visible;
 }
+
+/* ==========================================================================
+   Consent checkboxes
+   ========================================================================== */
 
 fieldset.narrative-consent {
     width: 720px;
@@ -1759,6 +1805,10 @@ fieldset.narrative-consent {
     margin-right: 13px !important;
 }
 
+/* ==========================================================================
+   Saving
+   ========================================================================== */
+
 .cr-save-option {
     margin-left: 0px;
     padding-left: 0px;
@@ -1793,6 +1843,10 @@ hr.save-method-hr,
 fieldset.save-method {
     padding: 12px 24px 32px 0;
 }
+
+/* ==========================================================================
+   Everything else
+   ========================================================================== */
 
 #attachment-alert {
     border: 1px solid #FFB149;

--- a/src/your-information.html
+++ b/src/your-information.html
@@ -406,13 +406,12 @@
             </label>
             <p class="label-subtext">We use this information to help identify trends in the marketplace.</p>
         </div>
-        <fieldset class="span9 cr-answer cr-radios prodselect cr-behalf">
+        <fieldset class="span9 cr-answer prodselect cr-behalf">
 
             <!-- question -->
             <div id="affiliation-question" class="row cr-question">
                 <div id="affiliation-options"
                      class="span9 cr-answer cr-radios cr-servicemember prodselect">
-
                     <label class="radio block">
                         <input type="checkbox"
                                name="cr-military-status"
@@ -431,15 +430,11 @@
                     </label>
                     <label class="radio block">
                         <input type="checkbox"
-                               name="cr-student"
+                               name="cr-small-business-owner"
                                value="option3"
-                               class="cr-need-over-62">
-                        A current student
-                        <br/><small>Includes any college or university degree program</small>
-                    </label>
-                    <label class="radio block">
-                        <input type="checkbox" name="cr-justice-involved" value="option3" class="cr-need-over-62">
-                        A person with a disability
+                               class="cr-small-business-owner"
+                               id="cr-small-business-owner">
+                        A small business owner
                     </label>
                 </div>
             </div>
@@ -602,6 +597,162 @@
                 <!-- /suffix -->
             </div>
             <!-- /city and state -->
+        </fieldset>
+        <fieldset id="small-business-owner-details"
+                  class="cr-fieldset affiliation-details cr-military-status">
+            <div class="affiliation-section">
+                <div class="span3 cr-label">
+                    <label>
+                        Is this complaint related to a small business you own?
+                        <small class="inline">(optional)</small>
+                    </label>
+                </div>
+                <div class="select-product-or-issue all-topissues">
+                    <label class="radio block">
+                        <input id="owns-business-yes" value="yes" name="owns-business" type="radio" class="radio_input">
+                        Yes
+                    </label>
+                    <label class="radio block">
+                        <input id="owns-business-no" value="no" name="owns-business" type="radio" class="radio_input">
+                        No
+                    </label>
+                </div>
+            </div>
+            <div id="small-business-owner-followups">
+                <div class="span3 cr-label">
+                    <label>
+                        Your business information
+                    </label>
+                </div>
+                <div class="affiliation-section">
+                    <div class="row cr-question">
+                        <div class="span3 cr-label cr-question-left">
+                            <label for="cr-business-name">
+                                Business name
+                                <small class="inline">(optional)</small>
+                            </label>
+                            <input type="text" name="cr-business-name" id="cr-business-name" class="input-large left">
+                        </div>
+                    </div>
+                </div>
+                <div class="affiliation-section">
+                    <div id="cr-business-address"
+                         class="row cr-question address-template"
+                         data-label="Business address"
+                         data-optional="true">
+                        <!-- Handlebars will add address template here. -->
+                    </div>
+                    <div class="row cr-question">
+                        <div class="span2 cr-label cr-question-left">
+                            <label for="cr-business-phone">
+                                Phone number
+                                <small class="inline">(optional)</small>
+                            </label>
+                            <input type="text"
+                                   name="cr-business-phone"
+                                   id="cr-business-phone">
+                        </div>
+                    </div>
+                </div>
+                <div class="affiliation-section">
+                    <div class="row cr-question">
+                        <div class="span3 cr-label cr-question-left">
+                            <label for="cr-business-">
+                                Industry
+                                <small class="inline">(optional)</small>
+                            </label>
+                            <select name="cr-business-" id="cr-business-">
+                                <option value="">Select an industry</option>
+                                <option value="">Accommodation and food services</option>
+                                <option value="">Administrative and support and waste management and remediation services</option>
+                                <option value="">Agriculture, forestry, fishing and hunting</option>
+                                <option value="">Arts, entertainment, and recreation</option>
+                                <option value="">Construction</option>
+                                <option value="">Educational services</option>
+                                <option value="">Health care and social assistance</option>
+                                <option value="">Information</option>
+                                <option value="">Finance and insurance</option>
+                                <option value="">Management of companies and enterprises</option>
+                                <option value="">Manufacturing</option>
+                                <option value="">Mining, quarrying, and oil and gas extraction</option>
+                                <option value="">Other services (except public administration)</option>
+                                <option value="">Professional, scientific, and technical services</option>
+                                <option value="">Public administration</option>
+                                <option value="">Real estate and rental and leasing</option>
+                                <option value="">Retail trade</option>
+                                <option value="">Transportation and warehousing</option>
+                                <option value="">Utilities</option>
+                                <option value="">Wholesale trade</option>
+                            </select>
+                        </div>
+                        <div class="span2 cr-label cr-question-right">
+                            <label for="cr-business-">
+                                Annual revenue
+                                <small class="inline">(optional)</small>
+                            </label>
+                            <select name="cr-business-" id="cr-business-">
+                                <option value="">Select a revenue range</option>
+                                <option value="">Less than $5,000</option>
+                                <option value="">$5,000 - $9,999</option>
+                                <option value="">$10,000 - $24,999</option>
+                                <option value="">$25,000 - $49,999</option>
+                                <option value="">$50,000 - $99,999</option>
+                                <option value="">$100,000 - $249,999</option>
+                                <option value="">$250,00 - $499,999</option>
+                                <option value="">$500,000 - $999,999</option>
+                                <option value="">$1,000,000 or more</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="row cr-question cr-question-last">
+                        <div class="span3 cr-label cr-question-left">
+                            <label for="cr-business-">
+                                Number of employees (including yourself)
+                                <small class="inline">(optional)</small>
+                            </label>
+                            <select name="cr-business-" id="cr-business-">
+                                <option value="">Select number of employees</option>
+                                <option value="">1</option>
+                                <option value="">2 to 4</option>
+                                <option value="">5 to 9</option>
+                                <option value="">10 to 19</option>
+                                <option value="">20 to 49</option>
+                                <option value="">50 to 99</option>
+                                <option value="">100 to 249</option>
+                                <option value="">250 to 499</option>
+                                <option value="">500 to 999</option>
+                                <option value="">1,000 or more</option>
+                            </select>
+                        </div>
+                        <div class="span2 cr-label cr-question-right">
+                            <label for="cr-business-">
+                                Amount borrowed
+                                <small class="inline">(optional)</small>
+                            </label>
+                            <p class="micro-copy">
+                                Consistent with lending practices, the below
+                                categories use an even dollar amount as the
+                                high-value in each dollar range.
+                            </p>
+                            <select name="cr-business-" id="cr-business-">
+                                <option value="">Select amount borrowed</option>
+                                <option value="">Not applicable</option>
+                                <option value="">$0-$2,500</option>
+                                <option value="">$2,501 - $5,000</option>
+                                <option value="">$5,001 - $10,000</option>
+                                <option value="">$10,001-$25,000</option>
+                                <option value="">$25,001-$50,000</option>
+                                <option value="">$50,001-$100,000</option>
+                                <option value="">$100,001-$250,000</option>
+                                <option value="">$250,001-$500,000</option>
+                                <option value="">$501,000-$1 million</option>
+                                <option value="">$1,000,001-$5 million</option>
+                                <option value="">$5,000,001 and over</option>
+                            </select>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </fieldset>
     </div>
 </fieldset>


### PR DESCRIPTION
Add small business affiliation and follow-up questions

## Additions

- Added small business affiliation and its follow-up questions

## Removals

- Removed student and disability affiliations

## Changes

- Updated the address handlebars template to allow for totally optional addresses (ones where all the fields are optional, as in the new small business affiliation)

## Testing

1. On step 5, select any of the "what people are involved" answers.
2. At the end of the primary consumer section, check the "A small business owner" affiliation. A single follow-up question, "Is this complaint related to a small business you own?" should appear.
3. Answer "yes" to that follow-up. An additional section of follow-up questions should appear.
4. Now answer "no" to the first follow-up question. The additional section of questions should disappear.
5. Try checking one or two other affiliations. Follow-up questions for those affiliations should appear above the small business follow-up questions.
6. Uncheck the small business owner affiliation. The small business follow-up questions should disappear.

## Screenshots

![small-business](https://cloud.githubusercontent.com/assets/1862695/21406711/fb7e1bfc-c79a-11e6-9c2a-fb517762bf94.gif)

## Todos

- Some of the content in step 5 has changed since this prototype was last updated. I'll handle content updates in a separate PR.